### PR TITLE
feat(menu): say that Water Alpha reaches models only on map load

### DIFF
--- a/engine/hexen2/menu.c
+++ b/engine/hexen2/menu.c
@@ -3267,6 +3267,20 @@ static void M_Rendering_Draw (void)
 	if (rendering_cursor == REND_EXTTEXTURES || rendering_cursor == REND_LEGACYALPHA)
 		M_Print (76, 92 + 8*REND_ITEMS, "applies on next map load");
 
+	/* r_wateralpha is split-brained and the row cannot say just one thing.
+	 * World water reads it per frame, so the slider is immediate there.  But
+	 * GL_Upload8 bakes it into an EF_TRANSPARENT alias skin's alpha at upload
+	 * (gl_draw.c, the `p & 1` arm) and Mod_RestoreIndexAlpha does the same for
+	 * a rebuilt replacement, so those models keep whatever was current when
+	 * they loaded.  That is 12 of the 13 EF_TRANSPARENT models in retail
+	 * content, 22% of their skin texels on average and nearly all of
+	 * stclrbm.mdl and boss/bone3.mdl -- visible enough to be worth saying.
+	 * uhexen2-xaon, which also records why deferring the factor to draw time
+	 * is not cheap: alpha already encodes three states, so there is no spare
+	 * room for a class marker that survives filtering. */
+	if (rendering_cursor == REND_WATERALPHA)
+		M_Print (76, 92 + 8*REND_ITEMS, "water now; models on map load");
+
 	/* search prompt below the menu (no row uses Y == REND_ITEMS+1) */
 	M_Filter_Draw (76, 92 + 8*(REND_ITEMS + 1));
 }


### PR DESCRIPTION
## What this changes

The Water Alpha row in Options → Display → Rendering now prints, while the cursor is on it:

```
WATER NOW; MODELS ON MAP LOAD
```

Partially addresses uhexen2-xaon.

## Why

That row controls two things with two different latencies, and said so for neither.

World water reads `r_wateralpha` per frame, so the slider is immediate there. But
`GL_Upload8` **bakes** it into an EF_TRANSPARENT alias skin's alpha at upload — the `p & 1`
arm in `gl_draw.c` — and `Mod_RestoreIndexAlpha` does the same for a rebuilt replacement. So
those models keep whatever value was current when they loaded.

I measured it rather than saying "some models". Of the 13 EF_TRANSPARENT models with an
embedded skin across data1, portals, sot, karma2 and soc, **12 have texels on that arm**,
22% of their skin texels on average:

| model | odd-index texels |
|---|---|
| `models/stclrbm.mdl` | 100.0% |
| `models/boss/bone3.mdl` | 99.6% |
| `models/eidoball.mdl` | 44.3% |
| `models/funnal.mdl` | 44.0% |
| `models/vorpshok.mdl` | 22.1% |
| `models/xhair.mdl` | 18.1% |

So lowering the slider visibly fails to reach real content until the next map load. It is
invisible at the default of 1.0, where the arm yields 255 and matches the solid case — only a
player who moves the slider is affected.

### Why not just fix it properly

Both routes were costed and both are out of proportion to a P3. Recorded in full on
uhexen2-xaon so the next person does not re-derive them:

**Re-upload on cvar change** is a dead end as the tree stands. `TexMgr_ReloadImage`,
`TexMgr_ReloadImages` and `TexMgr_ReloadNobrightImages` in `gl_texmgr.c` are all literally
`/* Stub for compatibility */` — there is no texture-reload machinery. And the source cannot
be recovered without re-reading the file: `Mod_LoadModel` takes the `.mdl` through
`FS_LoadStackFile` into a **stack buffer**, so the 8-bit skin is gone once loading finishes.
A callback would have to re-read and re-parse every affected model.

**Deferring the factor to draw time**, the way world water does, is blocked by encoding
rather than effort. Alpha already carries three states for these skins — 0 hole, wateralpha
class, 255 solid — and there is no fourth value that survives texture filtering. A sentinel
like `alpha == 1` gets blended with its neighbours by the mip chain and by linear filtering,
so the shader can no longer recognise the class. RGB is the colour; there is no spare channel.
Doing it properly means a second texture or a format change.

So the row is made honest rather than left silently half-live. uhexen2-xaon stays open with
a note to revisit if a model-reload path ever lands for another reason — at that point the
first option becomes nearly free and this hint should be replaced by the real thing.

## How it was tested

Driven through the real menu under Xvfb with `xdotool`:

- The hint draws on the Water Alpha row and nowhere else, and does not clip at 800x600.
- 72/72 JS unit tests pass; `.#h2ded-bundled` and `.#utils` build clean; `-help` boot check passes.

- **OS:** NixOS, Linux 6.18.47
- **GPU / driver:** llvmpipe (LLVM 21.1.8), GL 4.6 / GLSL 4.60
- **Game data:** the free demo data
- **Tested with:** base game

## Checklist

- [x] Builds locally (`nix build`)
- [x] Ran the game and reached the affected feature — navigated the actual menu
- [x] Tested at least one mod — n/a, menu text only
- [x] No legacy OpenGL introduced
- [x] Uses `__EMSCRIPTEN__`, not bare `EMSCRIPTEN` — n/a, no new guards
- [x] Ran `shellcheck` if release scripts changed — n/a
- [x] Cvar menu entry — n/a, the row already existed; this annotates it
- [x] Updated docs if behaviour changed — no behaviour change, menu text only
- [x] Unrelated cleanup is in separate commits
