### PR TITLE
ci(hexenworld): put hwsv behind a build and a smoke instead of nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,11 @@ jobs:
             echo "hwsv exited $status; expected 1 from Sys_Error"
             exit 1
           fi
-          grep -q 'FATAL ERROR: Unable to find a proper Hexen II installation' hwsv-smoke.log
+          if ! grep -q 'FATAL ERROR: Unable to find a proper Hexen II installation' hwsv-smoke.log; then
+            echo "hwsv exited 1, but not at the FS_Init data1 gate -- see the log above."
+            echo "Sys_Error exits 1 for every fatal, so the exit code alone proves nothing."
+            exit 1
+          fi
 
       - name: Build Windows
         run: nix build .#win64 --print-build-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,46 @@ jobs:
       - name: Build dedicated server
         run: nix build .#h2ded --print-build-logs
 
+      # BUILD_HEXENWORLD defaults OFF and no other target sets it, so until
+      # this step the whole of engine/hexenworld/{server,shared} -- and the
+      # -DH2W compile of the shared sources underneath it -- was gated by
+      # nothing at all.  h2ded above does not cover it: HexenWorld is a
+      # separate engine sharing h2shared, not a mode of the Hexen II server,
+      # so a change to quakefs.c or pr_edict.c can pass every step above and
+      # still break the only build that compiles them with H2W defined.  #35.
+      - name: Build HexenWorld dedicated server
+        run: nix build .#hwsv --print-build-logs
+
+      # Compiling hwsv does not prove it can reach main().  This runs it with
+      # no game data and asserts it dies at the FS_Init gate with a diagnostic
+      # -- exit code exactly 1, which is Sys_Error's exit(1), so a segfault
+      # (139) or a wedge that -k 5 has to kill (124) fails the step instead of
+      # passing as "nonzero".
+      #
+      # NOTE what this does NOT cover.  #35 asks for a smoke on the HexenWorld
+      # pak gate, Sys_Error("You must have the HexenWorld data installed") in
+      # engine/h2shared/quakefs.c.  That gate is unreachable here: FS_Init
+      # demands a valid Hexen II installation first, and a runner has no game
+      # data at all, so hwsv dies on the earlier data1/pak0.pak check and never
+      # looks for hw/pak4.pak.  Reaching the HexenWorld gate needs real data1
+      # present with hw/pak4.pak absent, and data1 is licensed content that
+      # cannot go in CI.  A green check here means hwsv starts and fails
+      # cleanly; it says nothing about HexenWorld data handling.
+      #
+      # -k 5 for the same reason as the Smoke test step above: the engine
+      # ignores SIGTERM during shutdown.
+      - name: Smoke test HexenWorld dedicated server
+        run: |
+          set -euo pipefail
+          status=0
+          timeout -k 5 30 nix run .#hwsv > hwsv-smoke.log 2>&1 || status=$?
+          head -20 hwsv-smoke.log
+          if [ "$status" -ne 1 ]; then
+            echo "hwsv exited $status; expected 1 from Sys_Error"
+            exit 1
+          fi
+          grep -q 'FATAL ERROR: Unable to find a proper Hexen II installation' hwsv-smoke.log
+
       - name: Build Windows
         run: nix build .#win64 --print-build-logs
 

--- a/engine/hexenworld/README.md
+++ b/engine/hexenworld/README.md
@@ -3,9 +3,13 @@
 Raven's QuakeWorld-derived multiplayer fork of Hexen II.  It is a *separate
 engine* that shares `h2shared` with Hexen II — its own protocol, its own
 gamecode (`hwprogs.dat`), its own client prediction and master server — not a
-mode of the Hexen II server.  Only the dedicated server (`hwsv`) is restored in
-this tree; the HexenWorld client (`hwcl` / `glhwcl`) and master (`hwmaster`) are
-not.
+mode of the Hexen II server.
+
+`engine/hexenworld/` holds only the dedicated server (`hwsv`); the HexenWorld
+client (`hwcl` / `glhwcl`) is not restored.  The master server and its helper
+tools *are* built, but from `hw_utils/` rather than here — `hwmaster`,
+`hwmquery`, `hwrcon` and `hwterm` all come out of `nix build .#utils`, which
+CI already runs.
 
 ## Building
 
@@ -98,8 +102,9 @@ before `Host_Init`.
 
 See GitHub issue #35.
 
-- Two `hwsv` instances discovering each other (heartbeat / `hwmaster`) —
-  `hwmaster` is not built in this tree.
+- Two `hwsv` instances discovering each other via `hwmaster`.  Not blocked on
+  building anything — `hwmaster` already ships in `.#utils`.  What is missing is
+  a harness that starts a master plus two servers and asserts the heartbeat.
 - A real HexenWorld client completing the connectionless handshake — `hwcl` is
   not built in this tree; needs an upstream or community client.
 - Whether this engine's modern wire extensions ride over the HexenWorld protocol

--- a/engine/hexenworld/README.md
+++ b/engine/hexenworld/README.md
@@ -1,0 +1,107 @@
+# HexenWorld (hwsv)
+
+Raven's QuakeWorld-derived multiplayer fork of Hexen II.  It is a *separate
+engine* that shares `h2shared` with Hexen II — its own protocol, its own
+gamecode (`hwprogs.dat`), its own client prediction and master server — not a
+mode of the Hexen II server.  Only the dedicated server (`hwsv`) is restored in
+this tree; the HexenWorld client (`hwcl` / `glhwcl`) and master (`hwmaster`) are
+not.
+
+## Building
+
+`hwsv` is behind a CMake option, default OFF:
+
+    cmake -DBUILD_HEXENWORLD=ON ...
+
+or via the flake:
+
+    nix build .#hwsv
+
+The flag is required at *configure* time — it gates whether `add_executable(hwsv)`
+is reached at all, so `make hwsv` without it asks for a target the generated
+build system does not contain.
+
+## Runtime data
+
+`hwsv` needs three things, none of which are in this repository.
+
+### 1. Hexen II retail data — `data1/pak0.pak`, `data1/pak1.pak`
+
+From your own Hexen II CD, patched to v1.11 (`h2patch`).  Licensed commercial
+data; not redistributable.  `FS_Init` refuses to start without it, before it
+ever looks at HexenWorld:
+
+    FATAL ERROR: Unable to find a proper Hexen II installation.
+
+Expected MD5s:
+
+    c9675191e75dd25a3b9ed81ee7e05eff  data1/pak0.pak
+    c2ac5b0640773eed9ebe1cda2eca2ad0  data1/pak1.pak
+
+### 2. HexenWorld data — `hw/pak4.pak`
+
+**This one is freely redistributable** and is *not* on any CD.  HexenWorld was
+Raven's free beta add-on; the pak's own bundled readme reads "this is the
+hexenworld pak file from Raven's latest beta release".  Hammer of Thyrion
+distributes it directly:
+
+    https://sourceforge.net/projects/uhexen2/files/Hexen2%20GameData/hexenworld-pakfiles/
+
+    curl -LO .../hexenworld-pakfiles-0.15.tgz
+    tar xzf hexenworld-pakfiles-0.15.tgz    # yields hw/pak4.pak
+    md5sum hw/pak4.pak                      # 88109ee385d9723ac5f1015e034a44dd
+
+Store it outside version control, in your game installation's `hw/` directory.
+Do not commit it.  `FS_Init`'s `GAME_HEXENWORLD` gate refuses to start without
+it (`engine/h2shared/quakefs.c`, "You must have the HexenWorld data installed").
+
+The engine recognises three vintages — 0.14/0.15 (10780245 bytes, the one
+above), and the older 0.11 and 0.09 betas.  Prefer 0.15.
+
+### 3. HexenWorld gamecode — `hw/hwprogs.dat`
+
+Built from source in this tree, so no acquisition problem — but nothing installs
+it into a game directory for you:
+
+    nix build .#gamecode
+    install -Dm644 result/share/hexenwail/hw/hwprogs.dat <gamedir>/hw/hwprogs.dat
+
+Without it `hwsv` gets all the way through `Host_Init` and then dies:
+
+    SV_Error: PR_LoadProgs: couldn't load hwprogs.dat
+
+## Verified bringup
+
+With all three in place, from the game installation directory:
+
+    $ hwsv +map demo1
+    HexenWorld server 0.29 (Linux)
+    Added packfile .../data1/pak0.pak (696 files)
+    Added packfile .../data1/pak1.pak (523 files)
+    Playing the registered version.
+    Added packfile .../hw/pak4.pak (102 files)
+    IP address 0.0.0.0:26950
+    UDP Initialized
+    ======== HexenWorld Initialized ========
+    Gamecode: hwprogs.dat from .../hw/hwprogs.dat (HW/v0.15, file crc 9155)
+    Building PHS...
+    Average leafs visible / hearable / total: 74 / 179 / 792
+
+The server then stays up serving on UDP 26950.
+
+Note the log ordering when something fails: `Sys_Error` writes to unbuffered
+stderr while the banner is buffered stdout flushed at exit, so a fatal error
+appears *above* the startup banner.  It does not mean the failure happened
+before `Host_Init`.
+
+## Not yet done
+
+See GitHub issue #35.
+
+- Two `hwsv` instances discovering each other (heartbeat / `hwmaster`) —
+  `hwmaster` is not built in this tree.
+- A real HexenWorld client completing the connectionless handshake — `hwcl` is
+  not built in this tree; needs an upstream or community client.
+- Whether this engine's modern wire extensions ride over the HexenWorld protocol
+  at all, or are Hexen II only.  Undecided; `hwsv` must not silently drop
+  clients that advertise them.

--- a/flake.nix
+++ b/flake.nix
@@ -380,6 +380,49 @@
             };
           });
 
+          # HexenWorld dedicated server (hwsv) — Raven's QuakeWorld-derived
+          # multiplayer fork.  A separate engine that shares h2shared, not a
+          # mode of h2ded, so h2ded's coverage buys it nothing: this is the
+          # only build anywhere that compiles engine/hexenworld/{server,shared}
+          # or the -DH2W flavour of the shared sources.  Ungated it rots, which
+          # is what it had been doing.  GitHub #35.
+          hwsv = pkgs.stdenv.mkDerivation (linuxBuildAttrs // {
+            pname = "hexenwail-hwsv";
+
+            # BUILD_HEXENWORLD is not h2ded's story with a different name.  It
+            # gates whether add_executable(hwsv) is reached at all, so the flag
+            # has to be set at *configure* time; buildFlags alone would ask for
+            # a target that the generated build system does not contain.  Both
+            # are needed -- the flag to create the target, buildFlags to build
+            # that one and not the client.
+            cmakeFlags = linuxBuildAttrs.cmakeFlags ++ [ "-DBUILD_HEXENWORLD=ON" ];
+            buildFlags = [ "hwsv" ];
+
+            installPhase = ''
+              runHook preInstall
+
+              install -Dm755 bin/hwsv $out/bin/hwsv
+
+              runHook postInstall
+            '';
+
+            meta = linuxBuildAttrs.meta // {
+              description = "Hexenwail HexenWorld dedicated server (headless hwsv)";
+              longDescription = ''
+                Headless HexenWorld server, built with -DH2W -DSERVERONLY from
+                engine/hexenworld plus the shared engine sources: its own
+                protocol, its own gamecode and its own client prediction, with
+                no renderer, video, sound or input.
+
+                Note: you still need the original game data files (pak0.pak,
+                pak1.pak) from the commercial game, and additionally the
+                official HexenWorld data (hw/pak4.pak) -- the engine refuses to
+                start without it.
+              '';
+              mainProgram = "hwsv";
+            };
+          });
+
           # Map/model toolchain (utils/) and HexenWorld servers (hw_utils/).
           # Configures the repo root rather than engine/, with the engine
           # switched off: the tools are plain C with no external dependencies


### PR DESCRIPTION
Item 5 of #35 (CI coverage), plus the item 1 acquisition write-up now that it is a verified recipe rather than a guess.

## The gap

`BUILD_HEXENWORLD` defaults OFF and nothing turned it on, so since `hwsv` came back nothing in CI compiled `engine/hexenworld/{server,shared}` or the `-DH2W` flavour of the shared sources. `h2ded` buys it no coverage — HexenWorld is a separate engine sharing `h2shared`, not a mode of the Hexen II server — so a `quakefs.c` or `pr_edict.c` change could pass every existing step and still break the only build that defines `H2W`.

## Changes

- **`.#hwsv` flake target.** `-DBUILD_HEXENWORLD=ON` at configure time *and* `buildFlags = [ "hwsv" ]`; both are required and they are not interchangeable. The option gates whether `add_executable(hwsv)` is reached at all, so without it `make hwsv` asks for a target the generated build system does not contain.
- **Build step** in CI, after the existing dedicated-server build.
- **Smoke step** that runs it with no game data and asserts it dies at `FS_Init` with exit code **exactly 1** — `Sys_Error`'s `exit(1)`. Asserting `-ne 1` rather than merely nonzero means a segfault (139) or a wedge that `-k 5` has to kill (124) fails the step instead of passing as "nonzero".
- **`engine/hexenworld/README.md`** — data acquisition and bringup.

## What the smoke does NOT cover

#35 asks for a smoke on the HexenWorld pak gate (`"You must have the HexenWorld data installed"`, `engine/h2shared/quakefs.c`). **That gate is unreachable in CI.** `FS_Init` demands a valid Hexen II installation first, and a runner has no `data1`, so `hwsv` dies on the earlier `data1/pak0.pak` check and never looks for `hw/pak4.pak`. Reaching it needs retail data present with `hw/pak4.pak` absent, and retail data cannot go in CI.

A green check here means hwsv starts and fails cleanly. It says nothing about HexenWorld data handling. The step comment says so, so a future reader does not mistake it.

## Runtime verification (new — #35 item 2)

`hw/pak4.pak` turns out to be **freely redistributable**, contrary to how #35 framed it. HexenWorld was Raven's free beta add-on; the pak's own bundled readme reads *"this is the hexenworld pak file from Raven's latest beta release"*, and Hammer of Thyrion distributes it directly under `Hexen2 GameData/hexenworld-pakfiles/`. Upstream's install doc gives HexenWorld no CD step, unlike every other pak. MD5 `88109ee385d9723ac5f1015e034a44dd`, verified.

The third ingredient, `hwprogs.dat`, already builds from this tree via `.#gamecode` — it is just never installed anywhere `hwsv` looks.

With all three in place, on a box with real retail data:

```
Added packfile .../hw/pak4.pak (102 files)
IP address 0.0.0.0:26950
UDP Initialized
======== HexenWorld Initialized ========
Gamecode: hwprogs.dat from .../hw/hwprogs.dat (HW/v0.15, file crc 9155)
Building PHS...
Average leafs visible / hearable / total: 74 / 179 / 792
```

```
UNCONN 0 0 0.0.0.0:26950 users:(("hwsv",pid=1214178,fd=7))
```

Past the pak gate, gamecode loaded, `demo1` loaded, PHS built, UDP 26950 bound, server stays up. **#35 item 2's first acceptance criterion is met.** The remaining two — two instances discovering each other, and a real client handshake — need `hwmaster` and `hwcl`, neither of which this tree builds.

## Validation

- `nix build .#hwsv` → `bin/hwsv`, 380792 bytes, clean
- CI smoke block extracted from `ci.yml` and run verbatim — passes
- `nix flake show --all-systems` — every output still evaluates
- `nix build .#h2ded` / `.#nixos` — still succeed, both cache hits, confirming the flake edit stays out of their input hashes

## Follow-ups (not in this PR)

- Pak-gate smoke via a synthetic minimal `data1/pak0.pak` — enough to satisfy the installation check, no Raven content — so `FS_Init` advances to the `hw` step.
- Installing `hwprogs.dat` into a game dir as part of a build target.
- #35 item 3 (do the modern wire extensions ride over the HexenWorld protocol) is still an open design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMow3sMwDRdhTWyXUucVwk
