### PR TITLE
feat(hexenworld): carry entity alpha, gated on a protocol of its own

### DIFF
--- a/engine/hexenworld/server/server.h
+++ b/engine/hexenworld/server/server.h
@@ -497,6 +497,7 @@ void SV_EndRedirect (void);
 //
 // sv_ents.c
 //
+void SV_ResolveAlphaField (void);
 void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg);
 void SV_WriteInventory (client_t *host_cl, edict_t *ent, sizebuf_t *msg);
 

--- a/engine/hexenworld/server/sv_ents.c
+++ b/engine/hexenworld/server/sv_ents.c
@@ -369,6 +369,19 @@ static void SV_WriteDelta (entity_state_t *from, entity_state_t *to, sizebuf_t *
 		bits |= U_ABSLIGHT;
 	}
 
+	/* Protocols 24-26 have no U_ALPHA -- 26 stops at U_ABSLIGHT -- and a client
+	 * that does not know to consume the alpha byte reads the next entity's bits
+	 * out of the middle of this one.  The gate is on the bit, not on the byte:
+	 * with U_ALPHA never set, `bits` is bit-for-bit what it is today, so the
+	 * U_MOREBITS2 test below and every write that follows behave identically for
+	 * a client on 24-26.  to->alpha is filled in regardless (see
+	 * SV_WriteEntitiesToClient), so a client that does negotiate
+	 * PROTOCOL_VERSION_HEXENWAIL_1 needs nothing re-derived. */
+	if (client->protocol >= PROTOCOL_VERSION_HEXENWAIL_1 && to->alpha != from->alpha)
+	{
+		bits |= U_ALPHA;
+	}
+
 	if (to->wpn_sound)
 	{	//not delta'ed, sound gets cleared after send
 		bits |= U_SOUND;
@@ -436,6 +449,16 @@ static void SV_WriteDelta (entity_state_t *from, entity_state_t *to, sizebuf_t *
 		MSG_WriteByte (msg, to->scale);
 	if (bits & U_ABSLIGHT)
 		MSG_WriteByte (msg, to->abslight);
+	/* No HexenWorld client in this tree reads this, so the position of the alpha
+	 * byte is being *defined* here rather than matched -- whoever writes the
+	 * reader must use this order.  Between U_ABSLIGHT and U_SOUND because it is
+	 * the one adjacency in this function that respects the bit order (U_ABSLIGHT
+	 * is bit 19, U_ALPHA bit 20 -- U_SOUND at bit 17 is already written out of
+	 * order), and because it puts alpha directly after the scale/abslight
+	 * appearance pair exactly as the Hexen II arm does in SV_WriteEntitiesToClient
+	 * (engine/hexen2/sv_main.c). */
+	if (bits & U_ALPHA)
+		MSG_WriteByte (msg, to->alpha);
 	if (bits & U_SOUND)
 		MSG_WriteShort (msg, to->wpn_sound);
 }
@@ -1398,6 +1421,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg)
 	edict_t	*clent;
 	client_frame_t	*frame;
 	entity_state_t	*state;
+	eval_t		*val;
 
 	// this is the frame we are creating
 	frame = &client->frames[client->netchan.incoming_sequence & UPDATE_MASK];
@@ -1464,6 +1488,13 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg)
 		state->scale = (int)(ent->v.scale * 100.0) & 255;
 		state->drawflags = ent->v.drawflags;
 		state->abslight = (int)(ent->v.abslight * 255.0) & 255;
+		/* Filled in for every client, not just PROTOCOL_VERSION_HEXENWAIL_1 ones,
+		 * so that the whole protocol decision lives at the single gate in
+		 * SV_WriteDelta and this stays a plain field like its neighbours.  hwprogs
+		 * has no native "alpha" field, so this is a progs-defined one and val is
+		 * NULL (-> ENTALPHA_DEFAULT) for gamecode that does not declare it. */
+		val = GetEdictFieldValue(ent, "alpha");
+		state->alpha = val ? ENTALPHA_ENCODE(val->_float) : ENTALPHA_DEFAULT;
 		//clear sound so it doesn't send twice
 		state->wpn_sound = ent->v.wpn_sound;
 	}

--- a/engine/hexenworld/server/sv_ents.c
+++ b/engine/hexenworld/server/sv_ents.c
@@ -283,6 +283,46 @@ static void SV_EmitPackedEntities(sizebuf_t *msg)
 
 //=============================================================================
 
+/* Offset of the progs-declared "alpha" field, in floats from &ent->v, or -1
+ * when the loaded gamecode declares no such field (stock hwprogs does not).
+ * Resolved once per map instead of calling GetEdictFieldValue(ent, "alpha")
+ * per entity per client per frame: that helper memoises only GEFV_CACHESIZE
+ * names and GEFV_CACHESIZE is 2 (h2shared/pr_edict.c), while this server
+ * already rotates "gravity" and "maxspeed" through the same two slots every
+ * frame (sv_user.c, sv_send.c).  A third name would therefore be evicted every
+ * frame and cost a full ED_FindField walk of progs->numfielddefs -- 531 entries
+ * for stock hwprogs.dat -- per client per frame, on a server that may have no
+ * protocol-100 client on it at all. */
+static int sv_alpha_field_ofs = -1;
+
+/*
+==================
+SV_ResolveAlphaField
+
+Find the gamecode's "alpha" field once, after PR_LoadProgs has built the field
+table.  Called from SV_SpawnServer; the result is only valid for the progs that
+were loaded, so it must be re-resolved on every map change.
+==================
+*/
+void SV_ResolveAlphaField (void)
+{
+	int		i, n;
+	ddef_t		*d;
+
+	sv_alpha_field_ofs = -1;
+
+	n = ED_NumFieldDefs ();
+	for (i = 0; i < n; i++)
+	{
+		d = ED_FieldDefAt (i);
+		if (d && !strcmp (PR_GetString (d->s_name), "alpha"))
+		{
+			sv_alpha_field_ofs = d->ofs;
+			return;
+		}
+	}
+}
+
 /*
 ==================
 SV_WriteDelta
@@ -1421,7 +1461,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg)
 	edict_t	*clent;
 	client_frame_t	*frame;
 	entity_state_t	*state;
-	eval_t		*val;
+	float		alpha_val;
 
 	// this is the frame we are creating
 	frame = &client->frames[client->netchan.incoming_sequence & UPDATE_MASK];
@@ -1489,12 +1529,18 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg)
 		state->drawflags = ent->v.drawflags;
 		state->abslight = (int)(ent->v.abslight * 255.0) & 255;
 		/* Filled in for every client, not just PROTOCOL_VERSION_HEXENWAIL_1 ones,
-		 * so that the whole protocol decision lives at the single gate in
-		 * SV_WriteDelta and this stays a plain field like its neighbours.  hwprogs
-		 * has no native "alpha" field, so this is a progs-defined one and val is
-		 * NULL (-> ENTALPHA_DEFAULT) for gamecode that does not declare it. */
-		val = GetEdictFieldValue(ent, "alpha");
-		state->alpha = val ? ENTALPHA_ENCODE(val->_float) : ENTALPHA_DEFAULT;
+		 * so that the whole protocol decision stays at the single gate in
+		 * SV_WriteDelta.  "alpha" is progs-declared rather than a native entvars_t
+		 * field, so it is read through the offset SV_ResolveAlphaField() found at
+		 * map load; gamecode that declares no such field leaves every entity at
+		 * ENTALPHA_DEFAULT. */
+		if (sv_alpha_field_ofs >= 0)
+		{
+			alpha_val = ((eval_t *)((char *)&ent->v + sv_alpha_field_ofs * 4))->_float;
+			state->alpha = ENTALPHA_ENCODE(alpha_val);
+		}
+		else
+			state->alpha = ENTALPHA_DEFAULT;
 		//clear sound so it doesn't send twice
 		state->wpn_sound = ent->v.wpn_sound;
 	}

--- a/engine/hexenworld/server/sv_init.c
+++ b/engine/hexenworld/server/sv_init.c
@@ -123,6 +123,27 @@ static void SV_CreateBaseline (void)
 		svent->baseline.scale = (int)(svent->v.scale*100.0)&255;
 		svent->baseline.drawflags = svent->v.drawflags;
 		svent->baseline.abslight = (int)(svent->v.abslight*255.0)&255;
+
+		/* DO NOT add "svent->baseline.alpha = ..." here.  The Hexen II arm does
+		 * exactly that (engine/hexen2/sv_main.c, SV_CreateBaseline) and copying it
+		 * for symmetry with the three lines above silently breaks entity alpha on
+		 * this arm.
+		 *
+		 * Why: the baseline goes into the one shared sv.signon buffer, which every
+		 * client replays verbatim, so it cannot be gated per client the way the
+		 * delta in SV_WriteDelta can -- and svc_spawnbaseline below carries no
+		 * alpha byte, because adding one would change the wire for stock 24-26
+		 * clients too.  So a client builds its baseline with alpha zeroed, and the
+		 * server's copy has to agree: baseline.alpha must stay 0
+		 * (== ENTALPHA_DEFAULT, which is why that constant is 0).  Hunk_AllocName
+		 * zeroes sv.edicts on every SV_SpawnServer and nothing else writes the
+		 * field, so today it does.
+		 *
+		 * Set it, and an entity with .alpha 0.5 standing in the map at load time
+		 * has to->alpha == from->alpha on its first delta, U_ALPHA never gets set,
+		 * and every protocol-100 client renders it opaque for the whole map.  There
+		 * is no HexenWorld client in this tree to catch that. */
+
 		//
 		// flush the signon message out to a seperate buffer if
 		// nearly full
@@ -333,6 +354,7 @@ void SV_SpawnServer (const char *server, const char *startspot)
 	// load progs to get entity field count
 	// which determines how big each edict is
 	PR_LoadProgs ();
+	SV_ResolveAlphaField ();	// must follow PR_LoadProgs: reads the field table
 	Host_LoadStrings();
 
 	// allocate edicts

--- a/engine/hexenworld/server/sv_main.c
+++ b/engine/hexenworld/server/sv_main.c
@@ -648,7 +648,17 @@ static void SVC_DirectConnect (void)
 		newcl->protocol = sv_protocol;
 	else {
 		s = Info_ValueForKey(userinfo, "*cap");
-		if (strstr(s, "c"))
+		/* "A" advertises PROTOCOL_VERSION_HEXENWAIL_1, and is tested before "c"
+		 * because 100 supersedes 26 -- a client claiming "A" is claiming every
+		 * behaviour 26 has (the chunked modellist/soundlist in sv_user.c gates on
+		 * >= PROTOCOL_VERSION_EXT and will fire for it) plus U_ALPHA.  Uppercase
+		 * on purpose: capability letters in the QuakeWorld/uHexen2 lineage are
+		 * lowercase and Info_SetValueForStarKey preserves case, so an uppercase
+		 * letter cannot arrive from a client that meant something else by it.
+		 * A client that advertises neither still lands on 25, exactly as before. */
+		if (strstr(s, "A"))
+			newcl->protocol = PROTOCOL_VERSION_HEXENWAIL_1;
+		else if (strstr(s, "c"))
 			newcl->protocol = PROTOCOL_VERSION_EXT;
 		else	newcl->protocol = PROTOCOL_VERSION;
 	}
@@ -1631,14 +1641,20 @@ void SV_Init (void)
 
 	i = COM_CheckParm ("-protocol");
 	if (i && i < com_argc - 1) {
+		/* -protocol forces the value on every client regardless of what it
+		 * advertised, so -protocol 100 will break a stock 25/26 client the same
+		 * way -protocol 26 already breaks a 25-only one.  It stays an explicit
+		 * operator action; the default (sv_protocol 0) negotiates from "*cap". */
 		switch ((sv_protocol = atoi (com_argv[i + 1]))) {
+		case PROTOCOL_VERSION_HEXENWAIL_1:
 		case PROTOCOL_VERSION_EXT:
 		case PROTOCOL_VERSION:
 			Sys_Printf ("Server using protocol %i\n", sv_protocol);
 			break;
 		default:
-			Sys_Error ("Bad protocol version request %i. Accepted values: %i, %i.",
-					sv_protocol, PROTOCOL_VERSION, PROTOCOL_VERSION_EXT);
+			Sys_Error ("Bad protocol version request %i. Accepted values: %i, %i, %i.",
+					sv_protocol, PROTOCOL_VERSION, PROTOCOL_VERSION_EXT,
+					PROTOCOL_VERSION_HEXENWAIL_1);
 		}
 	}
 

--- a/engine/hexenworld/server/sv_main.c
+++ b/engine/hexenworld/server/sv_main.c
@@ -651,11 +651,22 @@ static void SVC_DirectConnect (void)
 		/* "A" advertises PROTOCOL_VERSION_HEXENWAIL_1, and is tested before "c"
 		 * because 100 supersedes 26 -- a client claiming "A" is claiming every
 		 * behaviour 26 has (the chunked modellist/soundlist in sv_user.c gates on
-		 * >= PROTOCOL_VERSION_EXT and will fire for it) plus U_ALPHA.  Uppercase
-		 * on purpose: capability letters in the QuakeWorld/uHexen2 lineage are
-		 * lowercase and Info_SetValueForStarKey preserves case, so an uppercase
-		 * letter cannot arrive from a client that meant something else by it.
-		 * A client that advertises neither still lands on 25, exactly as before. */
+		 * >= PROTOCOL_VERSION_EXT and will fire for it) plus U_ALPHA.  A client
+		 * that advertises neither still lands on 25, exactly as before, and
+		 * Info_ValueForKey returns "" rather than NULL when the key is absent, so
+		 * strstr always has a string to walk.
+		 *
+		 * The stock client sets this key to exactly "c" -- one lowercase char, see
+		 * the since-deleted engine/hexenworld/client/cl_main.c in "hexenworld: if
+		 * the client sends '*caps' userinfo with a 'c', the server now returns
+		 * protocol 26 instead of 25..." (13b511e88 at time of writing) -- so it
+		 * cannot reach this branch.  What makes a *third-party* client safe is not
+		 * the choice of letter: SV_New_f puts host_client->protocol into
+		 * svc_serverdata (sv_user.c), and that client's CL_ParseServerData accepts
+		 * only 24/25/26 and calls Host_EndGame("Server returned unsupported
+		 * protocol %i") otherwise.  So a client that somehow advertised "A" without
+		 * meaning it gets a loud disconnect at connect time, before a single entity
+		 * delta is parsed -- never a silently corrupted one. */
 		if (strstr(s, "A"))
 			newcl->protocol = PROTOCOL_VERSION_HEXENWAIL_1;
 		else if (strstr(s, "c"))

--- a/engine/hexenworld/shared/protocol.h
+++ b/engine/hexenworld/shared/protocol.h
@@ -36,6 +36,15 @@
  *     client that negotiated 24-26 does not know to consume the alpha byte
  *     and would read the next entity's bits out of the middle of this one.
  *
+ * Known gap, so nobody assumes parity with the Hexen II arm: this covers
+ * packet entities only, never players.  SV_WriteEntitiesToClient's loop starts
+ * at MAX_CLIENTS+1 (sv_ents.c); players go out through
+ * SV_WritePlayersToClient as svc_playerinfo, whose pflags word is full --
+ * PF_SOUND is already bit 15 (below).  So ".alpha" on a player edict silently
+ * does nothing here, whereas on the Hexen II arm players are ordinary delta
+ * entities and do get it.  Closing that needs another wire-format change, not
+ * one more spare bit.
+ *
  * The number is 100 rather than 27 on purpose, for the same reason the Hexen
  * II arm chose 100 over 22 (see engine/hexen2/protocol.h): 27 is the next
  * value a Raven, UQE or Shanjaq descendant would reach for, and a silent

--- a/engine/hexenworld/shared/protocol.h
+++ b/engine/hexenworld/shared/protocol.h
@@ -25,6 +25,30 @@
 #define	OLD_PROTOCOL_VERSION	24
 #define	PROTOCOL_VERSION	25
 #define	PROTOCOL_VERSION_EXT	26
+#define	PROTOCOL_VERSION_HEXENWAIL_1	100	/* this engine's own extensions -- see below */
+
+/*
+ * PROTOCOL_VERSION_HEXENWAIL_1 exists because 24/25/26 are Raven's and
+ * uHexen2's wire formats and we do not get to add fields to them.  What it
+ * buys over 26 today is one thing:
+ *
+ *   - U_ALPHA in the entity delta (below).  26 stops at U_ABSLIGHT, so a
+ *     client that negotiated 24-26 does not know to consume the alpha byte
+ *     and would read the next entity's bits out of the middle of this one.
+ *
+ * The number is 100 rather than 27 on purpose, for the same reason the Hexen
+ * II arm chose 100 over 22 (see engine/hexen2/protocol.h): 27 is the next
+ * value a Raven, UQE or Shanjaq descendant would reach for, and a silent
+ * collision between two protocols that both claim "27" is undiagnosable from
+ * the client end.  100 also matches PROTOCOL_HEXENWAIL_1 on the Hexen II
+ * side, so "protocol 100 is this engine's extensions" is one fact, not two.
+ *
+ * NOT the default.  A server left alone negotiates exactly what it negotiates
+ * today: 26 for a client that advertises the "c" capability, 25 otherwise
+ * (SVC_DirectConnect, sv_main.c).  100 is reached only when the client
+ * advertises the "A" capability, or when the operator forces it with
+ * "-protocol 100".
+ */
 
 //=========================================
 
@@ -238,6 +262,23 @@
 #define	U_SOUND		(1<<17)
 #define	U_DRAWFLAGS	(1<<18)
 #define	U_ABSLIGHT	(1<<19)
+/* PROTOCOL_VERSION_HEXENWAIL_1 only.  Deliberately the same bit value as the
+ * Hexen II arm's U_ALPHA so the two entity deltas stay readable side by side.
+ * Bits 21-23 of the 3rd byte are still free, so nothing here needs a
+ * U_MOREBITS3 yet. */
+#define	U_ALPHA		(1<<20)
+
+/* Alpha encoding, copied verbatim from engine/hexen2/protocol.h so both arms
+ * of this engine put the same byte on the wire for the same "alpha" field.
+ * A reader wanting the float back uses ENTALPHA_DECODE. */
+#ifndef CLAMP
+#define CLAMP(minval,x,maxval) ((x) < (minval) ? (minval) : ((x) > (maxval) ? (maxval) : (x)))
+#endif
+#define ENTALPHA_DEFAULT	0	//entity's alpha is "default" -- must be zero so zeroed out memory works
+#define ENTALPHA_ZERO		1	//entity is invisible (lowest possible alpha)
+#define ENTALPHA_ONE		255	//entity is fully opaque (highest possible alpha)
+#define ENTALPHA_ENCODE(a)	(((a)==0)?ENTALPHA_DEFAULT:Q_rint(CLAMP(1,(a)*254.0f+1,255)))	//server convert to byte to send to client
+#define ENTALPHA_DECODE(a)	(((a)==ENTALPHA_DEFAULT)?1.0f:((float)(a)-1)/(254))	//client convert to float for rendering
 
 
 //==============================================
@@ -439,6 +480,8 @@ typedef struct
 	int		drawflags;		// for Alias models
 	int		abslight;		// for Alias models
 	int		wpn_sound;		// for cheap playing of sounds
+	byte		alpha;			// ENTALPHA encoding; only ever put on the wire
+					// for PROTOCOL_VERSION_HEXENWAIL_1 clients
 } entity_state_t;
 
 


### PR DESCRIPTION
Implements the item 3 decision recorded at https://github.com/hexenwail/hexenwail/issues/35#issuecomment-5562548129.

**Scope: `U_ALPHA` only.** The other two extensions `a65544389` bundled are deliberately not ported — `MAX_DATAGRAM` stays 1400 (Ethernet MTU minus headers; raising it forces IP fragmentation on the links HexenWorld exists to serve) and `MAX_MSGLEN` stays 7500 (its Hexen II counterpart was raised to fix an unchecked memcpy in `Datagram_GetMessage`'s fragment reassembly, and HexenWorld has no such code path).

## The bit

`U_ALPHA` takes `(1<<20)`, the same value it has on the Hexen II arm. The 3rd delta byte carries bits 16-23 and stopped at `U_ABSLIGHT (1<<19)`, so no `U_MOREBITS3` is needed and bits 21-23 stay free.

## The gate

Per-client on `PROTOCOL_VERSION_HEXENWAIL_1`, mirroring the `host_client->protocol >= PROTOCOL_VERSION_EXT` idiom already in `sv_user.c:170,246`. **100 rather than 27** for the same reason the Hexen II arm chose 100 over 22 — a low next-number is what a Raven/UQE/Shanjaq descendant reaches for, and 100 now means "this engine's extensions" on both arms rather than being two unrelated facts.

## Old-client invariant

The acceptance bar was: a client on protocol ≤ 26 must see byte-identical output. The argument, not just the assertion:

- The gate's first conjunct is false, so **`bits` never acquires bit 20**.
- `if (bits & 0xff0000) bits |= U_MOREBITS2` — bit 20 is inside that mask, so it is *precisely* the bit that could have made a 3rd byte appear where none appears today. It cannot.
- `if (bits & 511) bits |= U_MOREBITS` and `i = to->number | (bits & ~511)` read bits that are untouched.
- `MSG_WriteByte (msg, (bits >> 16) & 0xff)` — bit 20 lands at bit 4 of that byte; unset means an identical byte value.
- `if (!bits && !force) return;` — an entity whose *only* change is alpha still yields `bits == 0` and is still skipped, rather than newly emitting a zero-payload update.

## Baseline

`SV_CreateBaseline` writes one shared `sv.signon` buffer that cannot be gated per client, so the baseline deliberately does **not** carry alpha. `sv.edicts` comes from `Hunk_AllocName`, which memsets, so `baseline.alpha` is always `ENTALPHA_DEFAULT (0)` — which is also what a future client's zeroed baseline holds, so the first delta-from-baseline carries the real value and neither side ends up permanently dirty.

## Write order is *defined*, not matched

There is no HexenWorld client in this tree, so nothing reads this. The alpha byte goes between `U_ABSLIGHT` and `U_SOUND`: the one adjacency in that function that respects bit order (19 then 20; `U_SOUND` at bit 17 is already written out of order), and where the Hexen II arm puts it. The comment says outright that a reader must match this rather than the reverse.

## Validation

- `nix build .#hwsv` / `.#h2ded` / `.#nixos` — all pass, no new warnings
- Runtime from a full install: reaches `======== HexenWorld Initialized ========`, loads `hwprogs.dat (HW/v0.15, crc 9155)`, PHS `74 / 179 / 792` (identical to #35's reference run), `ss` confirms UDP 26950 bound
- `sv_protocol` still defaults to 0; a client advertising nothing still lands on 25

## Known-provisional, flagged for review

- **The `"A"` capability letter is invented.** Without a self-advertisement path the new protocol is only reachable via `-protocol 100`, which force-sets *every* connecting client and would break stock ones — so a cap letter is what makes a mixed server possible at all. But no client sends it, and if whoever writes `hwcl` picks a different token this is dead weight. Uppercase is deliberate (lineage cap letters are lowercase and `Info_SetValueForStarKey` preserves case), but the token itself is a guess.
- Alpha rides **only** the packetentities delta. Players (`svc_playerinfo`), the missile/raven compact updates, and the baseline do not carry it — deliberate for the baseline, out of scope for the rest.
- Stock `hwprogs.dat` declares no `.alpha` field, so `GetEdictFieldValue` returns NULL and everything encodes `ENTALPHA_DEFAULT`. Only a mod declaring `.float alpha` exercises this.
- **Untested end to end**, because there is no client. That was known and accepted when this was scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMow3sMwDRdhTWyXUucVwk
