### PR TITLE
feat(hexenworld): integrate client networking into Hexenwail

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -35,10 +35,13 @@ option(USE_FLUIDSYNTH "Use FluidSynth as the MIDI driver when available" ON)
 # tier 1 (no FluidSynth, or WASM).  FluidSynth always wins where present.
 option(USE_CODEC_TIMIDITY "Enable the vendored libTiMidity MIDI fallback codec" ON)
 
-# Off by default so `nix build` keeps producing exactly the client it does
-# today; the server is a separate, rarely-wanted artifact.
+# Dedicated servers are separate, rarely-wanted artifacts.  HexenWorld client
+# networking, by contrast, is part of Hexenwail itself; there is deliberately
+# no separate hwcl executable.  Emscripten is excluded below because this UDP
+# transport cannot run in a browser.
 option(BUILD_DEDICATED "Also build the h2ded dedicated server" OFF)
 option(BUILD_HEXENWORLD "Also build the hwsv HexenWorld dedicated server" OFF)
+option(USE_HEXENWORLD_CLIENT "Include HexenWorld networking in Hexenwail" ON)
 
 # The GL ES 3.0 render tier.  Emscripten/WebGL2 is one *instance* of it, not
 # the definition of it: everything the ES path does differently -- statically
@@ -852,6 +855,21 @@ else()
     set(RENDERER_SOURCES ${GL_RENDERER_SOURCES})
 endif()
 
+# HexenWorld uses a QuakeWorld-style UDP/netchan stack rather than Hexen II's
+# qsocket stack.  Compile that transport into Hexenwail under a namespace so
+# both protocols can live in the same process.  Client handshake and packet
+# parsing build on this layer; a standalone hwcl target is intentionally not
+# created.
+if(USE_HEXENWORLD_CLIENT AND NOT EMSCRIPTEN)
+    set(HW_CLIENT_NET_SOURCES
+        ${ENGINE_TOP}/hexen2/cl_hw.c
+        ${ENGINE_TOP}/hexenworld/shared/huffman.c
+        ${ENGINE_TOP}/hexenworld/shared/net_udp.c
+        ${ENGINE_TOP}/hexenworld/shared/net_chan.c
+    )
+    list(APPEND CLIENT_DEFINITIONS H2W_INTEGRATED)
+endif()
+
 set(ALL_SOURCES
     ${RENDERER_SOURCES}
     ${CLIENT_SOURCES}
@@ -859,6 +877,7 @@ set(ALL_SOURCES
     ${SOUND_SOURCES}
     ${SOUNDFONT_SOURCES}
     ${PLATFORM_SOURCES}
+    ${HW_CLIENT_NET_SOURCES}
 )
 
 # Create the executable

--- a/engine/h2shared/msg_io.c
+++ b/engine/h2shared/msg_io.c
@@ -201,7 +201,10 @@ void MSG_WriteUsercmd (sizebuf_t *buf, const usercmd_t *cmd, qboolean long_msg)
 //
 int		msg_readcount;
 qboolean	msg_badread;
-static sizebuf_t	*msg_readbuf;
+/* Defaults to net_message so a read that reaches the reader before any
+ * MSG_BeginReading behaves as it did when net_message was referenced
+ * directly, rather than dereferencing NULL. */
+static sizebuf_t	*msg_readbuf = &net_message;
 
 void MSG_BeginReadingFrom (sizebuf_t *message)
 {

--- a/engine/h2shared/msg_io.c
+++ b/engine/h2shared/msg_io.c
@@ -201,12 +201,24 @@ void MSG_WriteUsercmd (sizebuf_t *buf, const usercmd_t *cmd, qboolean long_msg)
 //
 int		msg_readcount;
 qboolean	msg_badread;
+static sizebuf_t	*msg_readbuf;
 
-void MSG_BeginReading (void)
+void MSG_BeginReadingFrom (sizebuf_t *message)
 {
+	msg_readbuf = message;
 	msg_readcount = 0;
 	msg_badread = false;
 }
+
+void MSG_BeginReading (void)
+{
+	MSG_BeginReadingFrom (&net_message);
+}
+
+/* Keep the established reader implementation below, but route it through the
+ * selected buffer.  This lets Hexen II and HexenWorld transports coexist in
+ * one client without copying packet payloads between their globals. */
+#define net_message (*msg_readbuf)
 
 // returns -1 and sets msg_badread if no more characters are available
 int MSG_ReadChar (void)

--- a/engine/h2shared/msg_io.h
+++ b/engine/h2shared/msg_io.h
@@ -38,6 +38,7 @@ void MSG_WriteUsercmd (sizebuf_t *sb, const struct usercmd_s *cmd, qboolean long
 #endif	/* H2W */
 
 void MSG_BeginReading (void);
+void MSG_BeginReadingFrom (sizebuf_t *message);
 int MSG_ReadChar (void);
 int MSG_ReadByte (void);
 int MSG_ReadShort (void);

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -1,0 +1,172 @@
+/*
+ * HexenWorld's QuakeWorld-derived connection transport inside Hexenwail.
+ *
+ * This intentionally owns no renderer or platform loop.  It is driven by the
+ * normal Hexenwail client frame and is the first layer of the protocol mode.
+ */
+#include "quakedef.h"
+#include "cl_hw.h"
+#include "../hexenworld/shared/net.h"
+#include "../hexenworld/shared/huffman.h"
+
+#define HW_PORT_CLIENT 26901
+#define HW_PORT_SERVER 26950
+#define HW_S2C_CONNECTION 'j'
+#define HW_A2C_PRINT 'n'
+#define HW_CLC_STRINGCMD 4
+
+typedef enum
+{
+	hwcl_disconnected,
+	hwcl_connecting,
+	hwcl_connected
+} hwcl_state_t;
+
+static hwcl_state_t hwcl_state;
+static qboolean hwcl_net_initialized;
+static netadr_t hwcl_server;
+static netchan_t hwcl_netchan;
+static double hwcl_connect_time;
+static qboolean hwcl_received_packet;
+
+static void HWCL_InitNet (void)
+{
+	if (hwcl_net_initialized)
+		return;
+
+	HuffInit ();
+	HWNetchan_Init ();
+	HWNET_Init (HW_PORT_CLIENT);
+	hwcl_net_initialized = true;
+}
+
+static void HWCL_SendConnectPacket (void)
+{
+	char data[256];
+	int portals;
+
+	portals = ((gameflags & GAME_PORTALS) == GAME_PORTALS);
+	q_snprintf (data, sizeof(data),
+			"%c%c%c%cconnect %d \"\\name\\%s\\playerclass\\%d\\*cap\\A\"\n",
+			255, 255, 255, 255, portals, cl_name.string,
+			(int)cl_playerclass.value);
+	HWNET_SendPacket (strlen(data), data, &hwcl_server);
+	hwcl_connect_time = realtime;
+	Con_Printf ("Connecting to HexenWorld server %s...\n",
+			HWNET_AdrToString (&hwcl_server));
+}
+
+qboolean HWCL_Connect (const char *host)
+{
+	HWCL_InitNet ();
+	HWCL_Disconnect ();
+
+	if (!HWNET_StringToAdr (host, &hwcl_server))
+	{
+		Con_Printf ("Bad HexenWorld server address: %s\n", host);
+		return false;
+	}
+	if (!hwcl_server.port)
+		hwcl_server.port = BigShort (HW_PORT_SERVER);
+
+	hwcl_state = hwcl_connecting;
+	HWCL_SendConnectPacket ();
+	return true;
+}
+
+qboolean HWCL_Active (void)
+{
+	return hwcl_state != hwcl_disconnected;
+}
+
+void HWCL_Disconnect (void)
+{
+	static const byte drop[] = {HW_CLC_STRINGCMD, 'd', 'r', 'o', 'p', 0};
+
+	if (hwcl_state == hwcl_connected)
+	{
+		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);
+		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);
+		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);
+	}
+	hwcl_state = hwcl_disconnected;
+	hwcl_received_packet = false;
+}
+
+static void HWCL_ConnectionlessPacket (void)
+{
+	int command;
+
+	MSG_BeginReadingFrom (&hw_net_message);
+	MSG_ReadLong (); /* connectionless -1 marker */
+	command = MSG_ReadByte ();
+
+	if (command == HW_S2C_CONNECTION)
+	{
+		if (hwcl_state != hwcl_connecting)
+			return;
+
+		HWNetchan_Setup (&hwcl_netchan, &hw_net_from);
+		MSG_WriteChar (&hwcl_netchan.message, HW_CLC_STRINGCMD);
+		MSG_WriteString (&hwcl_netchan.message, "new");
+		HWNetchan_Transmit (&hwcl_netchan, 0, NULL);
+		hwcl_state = hwcl_connected;
+		Con_Printf ("HexenWorld connection accepted.\n");
+		return;
+	}
+
+	if (command == HW_A2C_PRINT && hw_net_message.cursize > 5)
+		Con_Printf ("%s", (char *)hw_net_message.data + 5);
+}
+
+void HWCL_Frame (void)
+{
+	if (!hwcl_net_initialized || hwcl_state == hwcl_disconnected)
+		return;
+
+	if (hwcl_state == hwcl_connecting && realtime - hwcl_connect_time > 5.0)
+		HWCL_SendConnectPacket ();
+
+	while (HWNET_GetPacket ())
+	{
+		if (hw_net_message.cursize >= 4 &&
+		    hw_net_message.data[0] == 255 && hw_net_message.data[1] == 255 &&
+		    hw_net_message.data[2] == 255 && hw_net_message.data[3] == 255)
+		{
+			HWCL_ConnectionlessPacket ();
+			continue;
+		}
+
+		if (hwcl_state != hwcl_connected ||
+		    !HWNET_CompareAdr (&hw_net_from, &hwcl_netchan.remote_address))
+			continue;
+		if (!HWNetchan_Process (&hwcl_netchan))
+			continue;
+
+		/* The channel is live.  Server-message parsing is the next protocol
+		 * layer; keep acknowledging packets so reliable setup can progress. */
+		if (!hwcl_received_packet)
+		{
+			Con_Printf ("HexenWorld netchan established (%d payload bytes).\n",
+					hw_net_message.cursize - msg_readcount);
+			hwcl_received_packet = true;
+		}
+	}
+
+	/* Drive acknowledgements and reliable retransmission even when the server
+	 * has not sent a packet this render frame.  In particular, sequence zero is
+	 * rejected by the historical receiver, so the queued "new" command must
+	 * advance to sequence one on the following frame. */
+	if (hwcl_state == hwcl_connected && HWNetchan_CanPacket (&hwcl_netchan))
+		HWNetchan_Transmit (&hwcl_netchan, 0, NULL);
+}
+
+void HWCL_Shutdown (void)
+{
+	HWCL_Disconnect ();
+	if (hwcl_net_initialized)
+	{
+		HWNET_Shutdown ();
+		hwcl_net_initialized = false;
+	}
+}

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -21,29 +21,61 @@
 #define HW_PROTOCOL_VERSION 25
 #define HW_PROTOCOL_VERSION_EXT 26
 #define HW_PROTOCOL_VERSION_HEXENWAIL_1 100
+#define HW_SVC_NOP 1
 #define HW_SVC_DISCONNECT 2
 #define HW_SVC_UPDATESTAT 3
 #define HW_SVC_SETVIEW 5
+#define HW_SVC_SOUND 6
 #define HW_SVC_TIME 7
 #define HW_SVC_PRINT 8
 #define HW_SVC_STUFFTEXT 9
 #define HW_SVC_SETANGLE 10
 #define HW_SVC_SERVERDATA 11
 #define HW_SVC_LIGHTSTYLE 12
+#define HW_SVC_UPDATEFRAGS 14
+#define HW_SVC_STOPSOUND 16
 #define HW_SVC_SPAWNBASELINE 22
+#define HW_SVC_CENTERPRINT 26
+#define HW_SVC_KILLEDMONSTER 27
+#define HW_SVC_FOUNDSECRET 28
+#define HW_SVC_SPAWNSTATICSOUND 29
+#define HW_SVC_INTERMISSION 30
+#define HW_SVC_FINALE 31
+#define HW_SVC_CDTRACK 32
+#define HW_SVC_SELLSCREEN 33
+#define HW_SVC_SMALLKICK 34
+#define HW_SVC_BIGKICK 35
 #define HW_SVC_UPDATEPING 36
 #define HW_SVC_UPDATEENTERTIME 37
 #define HW_SVC_UPDATESTATLONG 38
+#define HW_SVC_MUZZLEFLASH 39
 #define HW_SVC_UPDATEUSERINFO 40
+#define HW_SVC_DOWNLOAD 41
 #define HW_SVC_PLAYERINFO 42
+#define HW_SVC_CHOKECOUNT 44
 #define HW_SVC_MODELLIST 45
 #define HW_SVC_SOUNDLIST 46
 #define HW_SVC_PACKETENTITIES 47
 #define HW_SVC_DELTAPACKETENTITIES 48
+#define HW_SVC_MAXSPEED 49
+#define HW_SVC_ENTGRAVITY 50
+#define HW_SVC_MIDI_NAME 65
+#define HW_SVC_TARGETUPDATE 69
+#define HW_SVC_SOUND_UPDATE_POS 71
+#define HW_SVC_UPDATE_PIV 72
+#define HW_SVC_PLAYER_SOUND 73
+#define HW_SVC_UPDATEPCLASS 74
 #define HW_SVC_UPDATEDMINFO 75
 #define HW_SVC_UPDATESIEGEINFO 76
 #define HW_SVC_UPDATESIEGETEAM 77
 #define HW_SVC_UPDATESIEGELOSSES 78
+#define HW_SVC_HASKEY 79
+#define HW_SVC_NONEHASKEY 80
+#define HW_SVC_ISDOC 81
+#define HW_SVC_NODOC 82
+#define HW_SVC_PLAYERSKIPPED 83
+#define HW_SND_VOLUME (1 << 15)
+#define HW_SND_ATTENUATION (1 << 14)
 #define HWCL_MAX_ENTITIES 768
 #define HWCL_MAX_CLIENTS 32
 
@@ -92,6 +124,12 @@ static struct
 	vec3_t viewangles;
 	int viewentity;
 	int stats[MAX_CL_STATS];
+	int cdtrack;
+	int chokecount;
+	int piv;
+	float maxspeed;
+	float entgravity;
+	char midi_name[MAX_QPATH];
 	hwcl_entity_state_t baselines[HWCL_MAX_ENTITIES];
 	hwcl_entity_state_t entities[HWCL_MAX_ENTITIES];
 	hwcl_entity_state_t players[HWCL_MAX_CLIENTS];
@@ -314,6 +352,50 @@ static void HWCL_SkipUsercmd (void)
 	if (bits & (1 << 7)) MSG_ReadByte ();
 }
 
+static void HWCL_ParseSound (void)
+{
+	int channel;
+	int i;
+
+	channel = MSG_ReadShort ();
+	if (channel & HW_SND_VOLUME)
+		MSG_ReadByte ();
+	if (channel & HW_SND_ATTENUATION)
+		MSG_ReadByte ();
+	MSG_ReadByte (); /* sound index */
+	for (i = 0; i < 3; i++)
+		MSG_ReadCoord ();
+}
+
+static void HWCL_ParseDownload (void)
+{
+	int size;
+	int i;
+
+	size = MSG_ReadShort ();
+	MSG_ReadByte (); /* percent */
+	if (size <= 0 || msg_badread)
+		return;
+	for (i = 0; i < size; i++)
+		MSG_ReadByte ();
+}
+
+static void HWCL_SkipCoords (int count)
+{
+	int i;
+
+	for (i = 0; i < count; i++)
+		MSG_ReadCoord ();
+}
+
+static void HWCL_SkipAngles (int count)
+{
+	int i;
+
+	for (i = 0; i < count; i++)
+		MSG_ReadAngle ();
+}
+
 static void HWCL_ParsePlayerInfo (void)
 {
 	hwcl_entity_state_t discard = {0};
@@ -365,6 +447,8 @@ static void HWCL_ParseServerMessage (void)
 		command = MSG_ReadByte ();
 		switch (command)
 		{
+		case HW_SVC_NOP:
+			break;
 		case HW_SVC_PRINT:
 			MSG_ReadByte (); /* print level */
 			text = MSG_ReadString ();
@@ -400,6 +484,45 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadByte ();
 			MSG_ReadString ();
 			break;
+		case HW_SVC_SOUND:
+			HWCL_ParseSound ();
+			break;
+		case HW_SVC_UPDATEFRAGS:
+			MSG_ReadByte ();
+			MSG_ReadShort ();
+			break;
+		case HW_SVC_STOPSOUND:
+			MSG_ReadShort ();
+			break;
+		case HW_SVC_CENTERPRINT:
+			MSG_ReadString ();
+			break;
+		case HW_SVC_KILLEDMONSTER:
+		case HW_SVC_FOUNDSECRET:
+		case HW_SVC_SELLSCREEN:
+		case HW_SVC_SMALLKICK:
+		case HW_SVC_BIGKICK:
+			break;
+		case HW_SVC_SPAWNSTATICSOUND:
+			HWCL_SkipCoords (3);
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_INTERMISSION:
+			HWCL_SkipCoords (3);
+			HWCL_SkipAngles (3);
+			break;
+		case HW_SVC_FINALE:
+			MSG_ReadString ();
+			break;
+		case HW_SVC_CDTRACK:
+			hwcl_server_state.cdtrack = MSG_ReadByte ();
+			break;
+		case HW_SVC_MIDI_NAME:
+			q_strlcpy (hwcl_server_state.midi_name, MSG_ReadString (),
+					sizeof(hwcl_server_state.midi_name));
+			break;
 		case HW_SVC_UPDATEPING:
 			MSG_ReadByte ();
 			MSG_ReadShort ();
@@ -415,10 +538,16 @@ static void HWCL_ParseServerMessage (void)
 			else
 				MSG_ReadLong ();
 			break;
+		case HW_SVC_MUZZLEFLASH:
+			MSG_ReadShort ();
+			break;
 		case HW_SVC_UPDATEUSERINFO:
 			MSG_ReadByte ();
 			MSG_ReadLong ();
 			MSG_ReadString ();
+			break;
+		case HW_SVC_DOWNLOAD:
+			HWCL_ParseDownload ();
 			break;
 		case HW_SVC_PLAYERINFO:
 			HWCL_ParsePlayerInfo ();
@@ -428,6 +557,46 @@ static void HWCL_ParseServerMessage (void)
 			break;
 		case HW_SVC_DELTAPACKETENTITIES:
 			HWCL_ParsePacketEntities (true);
+			break;
+		case HW_SVC_CHOKECOUNT:
+			hwcl_server_state.chokecount = MSG_ReadByte ();
+			break;
+		case HW_SVC_MAXSPEED:
+			hwcl_server_state.maxspeed = MSG_ReadFloat ();
+			break;
+		case HW_SVC_ENTGRAVITY:
+			hwcl_server_state.entgravity = MSG_ReadFloat ();
+			break;
+		case HW_SVC_TARGETUPDATE:
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_SOUND_UPDATE_POS:
+			MSG_ReadShort ();
+			HWCL_SkipCoords (3);
+			break;
+		case HW_SVC_UPDATE_PIV:
+			hwcl_server_state.piv = MSG_ReadLong ();
+			break;
+		case HW_SVC_PLAYER_SOUND:
+			MSG_ReadByte ();
+			HWCL_SkipCoords (3);
+			MSG_ReadShort ();
+			break;
+		case HW_SVC_UPDATEPCLASS:
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_HASKEY:
+		case HW_SVC_NONEHASKEY:
+		case HW_SVC_ISDOC:
+		case HW_SVC_NODOC:
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_PLAYERSKIPPED:
+			MSG_ReadByte ();
 			break;
 		case HW_SVC_UPDATEDMINFO:
 			MSG_ReadByte ();

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -24,6 +24,7 @@
 #define HW_SVC_PRINT 8
 #define HW_SVC_STUFFTEXT 9
 #define HW_SVC_SERVERDATA 11
+#define HW_SVC_SPAWNBASELINE 22
 #define HW_SVC_MODELLIST 45
 #define HW_SVC_SOUNDLIST 46
 
@@ -130,6 +131,24 @@ static void HWCL_ParseServerData (void)
 	HWCL_StringCmd (va ("soundlist %d 0", hwcl_servercount));
 }
 
+/* Signon buffers contain baseline records before their svc_stufftext request.
+ * Consume their wire representation now; retaining baselines for entity delta
+ * reconstruction belongs with the client-state adapter. */
+static void HWCL_SkipBaseline (void)
+{
+	int i;
+
+	MSG_ReadShort (); /* entity number */
+	MSG_ReadShort (); /* model */
+	for (i = 0; i < 6; i++)
+		MSG_ReadByte (); /* frame through absolute light */
+	for (i = 0; i < 3; i++)
+	{
+		MSG_ReadCoord ();
+		MSG_ReadAngle ();
+	}
+}
+
 static void HWCL_ParseServerMessage (void)
 {
 	int command;
@@ -155,10 +174,22 @@ static void HWCL_ParseServerMessage (void)
 		case HW_SVC_MODELLIST:
 			HWCL_ParsePrecacheList (true);
 			break;
+		case HW_SVC_SPAWNBASELINE:
+			HWCL_SkipBaseline ();
+			break;
 		case HW_SVC_STUFFTEXT:
 			text = MSG_ReadString ();
 			if (!msg_badread)
+			{
 				Con_DPrintf ("HexenWorld server command: %s", text);
+				/* This is a server-directed signon request, not console text: the
+				 * Hexen II command buffer uses a different transport.  Restrict it
+				 * to the three documented handshake commands. */
+				if (!q_strncasecmp (text, "cmd prespawn ", 13) ||
+					!q_strncasecmp (text, "cmd spawn ", 10) ||
+					!q_strncasecmp (text, "cmd begin", 9))
+					HWCL_StringCmd (text + 4);
+			}
 			break;
 		default:
 			/* Do not desynchronise the reader by guessing unknown message sizes.

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -219,6 +219,7 @@ typedef struct
 	int buttons;
 	int impulse;
 	int msec;
+	int lightlevel;
 } hwcl_usercmd_t;
 
 static hwcl_usercmd_t hwcl_cmd_history[3];
@@ -257,7 +258,12 @@ static int HWCL_QuantizeMove (int move)
 	return (int)(move * 0.25f);
 }
 
-static void HWCL_WriteUsercmd (sizebuf_t *buf, const hwcl_usercmd_t *cmd)
+/* The third command in a clc_move is the "long" form: SV_ReadClientMessage
+ * reads it with MSG_ReadUsercmd(..., true), which consumes a light_level byte
+ * straight after the bits byte.  Omitting it shifts every following field and
+ * desynchronises the server's read of the whole packet. */
+static void HWCL_WriteUsercmd (sizebuf_t *buf, const hwcl_usercmd_t *cmd,
+		qboolean long_msg)
 {
 	int bits = 0;
 
@@ -271,6 +277,8 @@ static void HWCL_WriteUsercmd (sizebuf_t *buf, const hwcl_usercmd_t *cmd)
 	if (cmd->msec) bits |= (1 << 7);
 
 	MSG_WriteByte (buf, bits);
+	if (long_msg)
+		MSG_WriteByte (buf, cmd->lightlevel);
 	if (bits & (1 << 0)) HWCL_WriteAngle16 (buf, cmd->angles[0]);
 	HWCL_WriteAngle16 (buf, cmd->angles[1]);
 	if (bits & (1 << 1)) HWCL_WriteAngle16 (buf, cmd->angles[2]);
@@ -351,25 +359,41 @@ static void HWCL_LoadSounds (void)
  * start at one. */
 static void HWCL_ParsePrecacheList (qboolean models)
 {
+	int limit = models ? MAX_MODELS : MAX_SOUNDS;
 	int index = 1;
 	int next;
 	const char *entry;
 
+	/* Protocol 26+ prefixes the chunk with its zero-based start offset.  It
+	 * comes straight off the wire, so clamp it before it can be used as a
+	 * count: storing is bounds-checked below, but the retained *_count feeds
+	 * the HWCL_Load* loops, which index cl.model_precache / cl.sound_precache
+	 * directly. */
 	if (hwcl_protocol >= HW_PROTOCOL_VERSION_EXT)
+	{
 		index = MSG_ReadLong () + 1;
+		if (index < 1 || index > limit)
+		{
+			Con_Printf ("HexenWorld %s list offset out of range.\n",
+					models ? "model" : "sound");
+			HWCL_Disconnect ();
+			return;
+		}
+	}
 	for (;;)
 	{
 		entry = MSG_ReadString ();
 		if (!entry[0] || msg_badread)
 			break;
-		if (index > 0 && (models ? index < MAX_MODELS : index < MAX_SOUNDS))
+		if (index > 0 && index < limit)
 		{
 			if (models)
 				q_strlcpy (hwcl_model_names[index], entry, MAX_QPATH);
 			else
 				q_strlcpy (hwcl_sound_names[index], entry, MAX_QPATH);
 		}
-		index++;
+		if (index < limit)
+			index++;
 	}
 	if (msg_badread)
 		return;
@@ -389,14 +413,16 @@ static void HWCL_ParsePrecacheList (qboolean models)
 
 	if (models)
 	{
-		hwcl_model_count = index > hwcl_model_count ? index : hwcl_model_count;
+		if (index > hwcl_model_count)
+			hwcl_model_count = index;
 		HWCL_LoadModels ();
 		Con_Printf ("HexenWorld precache lists received; requesting signon.\n");
 		HWCL_StringCmd (va ("prespawn %d 0", hwcl_servercount));
 	}
 	else
 	{
-		hwcl_sound_count = index > hwcl_sound_count ? index : hwcl_sound_count;
+		if (index > hwcl_sound_count)
+			hwcl_sound_count = index;
 		HWCL_LoadSounds ();
 		HWCL_StringCmd (va ("modellist %d 0", hwcl_servercount));
 	}
@@ -1088,9 +1114,10 @@ void HWCL_ApplyState (void)
 	int highest = 0;
 	int viewentity;
 
-	cl.mtime[1] = cl.mtime[0];
-	cl.mtime[0] = hwcl_server_state.server_time;
-	cl.time = cl.mtime[0];
+	/* cl.mtime is shifted by HW_SVC_TIME and cl.time is advanced by
+	 * CL_AdvanceTime, exactly as on the Hexen II path.  Re-shifting mtime
+	 * here every rendered frame and pinning cl.time to mtime[0] would hold
+	 * the lerp fraction at 1 and make every entity snap between updates. */
 	for (i = 0; i < MAX_CL_STATS; i++)
 		cl.stats[i] = hwcl_server_state.stats[i];
 
@@ -1275,6 +1302,8 @@ static void HWCL_ParseServerMessage (void)
 			break;
 		case HW_SVC_TIME:
 			hwcl_server_state.server_time = MSG_ReadFloat ();
+			cl.mtime[1] = cl.mtime[0];
+			cl.mtime[0] = hwcl_server_state.server_time;
 			break;
 		case HW_SVC_SETANGLE:
 			hwcl_server_state.viewangles[0] = MSG_ReadAngle ();
@@ -1666,6 +1695,7 @@ void HWCL_SendCmd (const usercmd_t *cmd)
 	current.upmove = (int)cmd->upmove;
 	current.buttons = CL_GetButtonBits ();
 	current.impulse = CL_GetImpulse ();
+	current.lightlevel = cmd->lightlevel;
 	msec = (int)(host_frametime * 1000.0 + 0.5);
 	if (msec < 1)
 		msec = 1;
@@ -1681,8 +1711,13 @@ void HWCL_SendCmd (const usercmd_t *cmd)
 		hwcl_have_cmd_history = true;
 	}
 
-	oldest = hwcl_cmd_history[0];
-	oldcmd = hwcl_cmd_history[1];
+	/* history[2] is the previous frame's command and history[1] the one
+	 * before it -- SV_ReadClientMessage replays oldest at net_drop > 1 and
+	 * oldcmd at net_drop > 0, so these must be cmd[n-2] and cmd[n-1].
+	 * Reading [0]/[1] here skipped the most recent backup, which is exactly
+	 * the command a single dropped packet needs to recover. */
+	oldest = hwcl_cmd_history[1];
+	oldcmd = hwcl_cmd_history[2];
 	/* Impulses are one-shot commands.  Replaying them from the two backup
 	 * commands would fire a weapon or select an item multiple times. */
 	oldest.impulse = 0;
@@ -1690,9 +1725,9 @@ void HWCL_SendCmd (const usercmd_t *cmd)
 
 	SZ_Init (&buf, data, sizeof(data));
 	MSG_WriteByte (&buf, HW_CLC_MOVE);
-	HWCL_WriteUsercmd (&buf, &oldest);
-	HWCL_WriteUsercmd (&buf, &oldcmd);
-	HWCL_WriteUsercmd (&buf, &current);
+	HWCL_WriteUsercmd (&buf, &oldest, false);
+	HWCL_WriteUsercmd (&buf, &oldcmd, false);
+	HWCL_WriteUsercmd (&buf, &current, true);
 	HWNetchan_Transmit (&hwcl_netchan, buf.cursize, buf.data);
 
 	for (i = 0; i < 2; i++)
@@ -1717,9 +1752,15 @@ void HWCL_Disconnect (void)
 		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);
 		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);
 	}
+	/* CL_Disconnect calls this unconditionally, so only touch cls.state when
+	 * HexenWorld actually owned the connection.  Clearing it for a plain
+	 * Hexen II session skips CL_Disconnect's own ca_connected block, which is
+	 * what sends clc_disconnect, closes the qsocket, shuts down a listen
+	 * server and removes the .gip files. */
+	if (hwcl_state != hwcl_disconnected)
+		cls.state = ca_disconnected;
 	hwcl_state = hwcl_disconnected;
 	hwcl_received_packet = false;
-	cls.state = ca_disconnected;
 }
 
 static void HWCL_ConnectionlessPacket (void)
@@ -1744,8 +1785,15 @@ static void HWCL_ConnectionlessPacket (void)
 		return;
 	}
 
-	if (command == HW_A2C_PRINT && hw_net_message.cursize > 5)
-		Con_Printf ("%s", (char *)hw_net_message.data + 5);
+	if (command == HW_A2C_PRINT)
+	{
+		/* NET_GetPacket sets cursize from the Huffman decode and never
+		 * terminates the buffer, so the payload must be read through the
+		 * bounds-checked reader rather than as a bare C string. */
+		const char *text = MSG_ReadString ();
+		if (!msg_badread)
+			Con_Printf ("%s", text);
+	}
 }
 
 void HWCL_Frame (void)

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -31,8 +31,11 @@
 #define HW_SVC_UPDATEENTERTIME 37
 #define HW_SVC_UPDATESTATLONG 38
 #define HW_SVC_UPDATEUSERINFO 40
+#define HW_SVC_PLAYERINFO 42
 #define HW_SVC_MODELLIST 45
 #define HW_SVC_SOUNDLIST 46
+#define HW_SVC_PACKETENTITIES 47
+#define HW_SVC_DELTAPACKETENTITIES 48
 #define HW_SVC_UPDATEDMINFO 75
 #define HW_SVC_UPDATESIEGEINFO 76
 #define HW_SVC_UPDATESIEGETEAM 77
@@ -159,6 +162,99 @@ static void HWCL_SkipBaseline (void)
 	}
 }
 
+/* Consume an entity delta without retaining it.  This keeps the packet stream
+ * synchronised until the state adapter can map these records to Hexenwail's
+ * client entities. */
+static void HWCL_SkipEntityDelta (int bits)
+{
+	/* The low nine bits are the entity number, not flags. */
+	bits &= ~511;
+	if (bits & (1 << 15))
+		bits |= MSG_ReadByte ();
+	if (bits & (1 << 7))
+		bits |= MSG_ReadByte () << 16;
+	if (bits & (1 << 16))
+	{
+		if (bits & (1 << 6))
+			MSG_ReadShort ();
+		else
+			MSG_ReadByte ();
+	}
+	if (bits & (1 << 13)) MSG_ReadByte ();
+	if (bits & (1 << 3)) MSG_ReadByte ();
+	if (bits & (1 << 4)) MSG_ReadByte ();
+	if (bits & (1 << 18)) MSG_ReadByte ();
+	if (bits & (1 << 5)) MSG_ReadLong ();
+	if (bits & (1 << 9)) MSG_ReadCoord ();
+	if (bits & (1 << 0)) MSG_ReadAngle ();
+	if (bits & (1 << 10)) MSG_ReadCoord ();
+	if (bits & (1 << 12)) MSG_ReadAngle ();
+	if (bits & (1 << 11)) MSG_ReadCoord ();
+	if (bits & (1 << 1)) MSG_ReadAngle ();
+	if (bits & (1 << 2)) MSG_ReadByte ();
+	if (bits & (1 << 19)) MSG_ReadByte ();
+	if (bits & (1 << 17)) MSG_ReadShort ();
+	if (bits & (1 << 20)) MSG_ReadByte ();
+}
+
+static void HWCL_SkipPacketEntities (qboolean delta)
+{
+	int bits;
+
+	if (delta)
+		MSG_ReadByte (); /* source sequence */
+	for (;;)
+	{
+		bits = (unsigned short)MSG_ReadShort ();
+		if (!bits || msg_badread)
+			return;
+		if (!(bits & (1 << 14))) /* U_REMOVE has no payload */
+			HWCL_SkipEntityDelta (bits);
+		if (msg_badread)
+			return;
+	}
+}
+
+static void HWCL_SkipUsercmd (void)
+{
+	int bits = MSG_ReadByte ();
+
+	if (bits & (1 << 0)) MSG_ReadShort ();
+	MSG_ReadShort (); /* angle 2 is always present */
+	if (bits & (1 << 1)) MSG_ReadShort ();
+	if (bits & (1 << 2)) MSG_ReadChar ();
+	if (bits & (1 << 3)) MSG_ReadChar ();
+	if (bits & (1 << 4)) MSG_ReadChar ();
+	if (bits & (1 << 5)) MSG_ReadByte ();
+	if (bits & (1 << 6)) MSG_ReadByte ();
+	if (bits & (1 << 7)) MSG_ReadByte ();
+}
+
+static void HWCL_SkipPlayerInfo (void)
+{
+	int flags;
+	int i;
+
+	MSG_ReadByte (); /* player slot */
+	flags = (unsigned short)MSG_ReadShort ();
+	for (i = 0; i < 3; i++)
+		MSG_ReadCoord ();
+	MSG_ReadByte (); /* frame */
+	if (flags & (1 << 0)) MSG_ReadByte (); /* msec */
+	if (flags & (1 << 1)) HWCL_SkipUsercmd ();
+	for (i = 0; i < 3; i++)
+		if (flags & (1 << (2 + i))) MSG_ReadShort ();
+	if (flags & (1 << 5)) MSG_ReadShort ();
+	if (flags & (1 << 6)) MSG_ReadByte ();
+	if (flags & (1 << 7)) MSG_ReadByte ();
+	if (flags & (1 << 11)) MSG_ReadByte ();
+	if (flags & (1 << 8)) MSG_ReadByte ();
+	if (flags & (1 << 12)) MSG_ReadByte ();
+	if (flags & (1 << 13)) MSG_ReadByte ();
+	if (flags & (1 << 14)) MSG_ReadByte ();
+	if (flags & (1 << 15)) MSG_ReadShort ();
+}
+
 static void HWCL_ParseServerMessage (void)
 {
 	int command;
@@ -201,6 +297,15 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadByte ();
 			MSG_ReadLong ();
 			MSG_ReadString ();
+			break;
+		case HW_SVC_PLAYERINFO:
+			HWCL_SkipPlayerInfo ();
+			break;
+		case HW_SVC_PACKETENTITIES:
+			HWCL_SkipPacketEntities (false);
+			break;
+		case HW_SVC_DELTAPACKETENTITIES:
+			HWCL_SkipPacketEntities (true);
 			break;
 		case HW_SVC_UPDATEDMINFO:
 			MSG_ReadByte ();

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -44,6 +44,7 @@
 #define HW_SVC_UPDATESIEGEINFO 76
 #define HW_SVC_UPDATESIEGETEAM 77
 #define HW_SVC_UPDATESIEGELOSSES 78
+#define HWCL_MAX_ENTITIES 768
 
 typedef enum
 {
@@ -60,17 +61,36 @@ static double hwcl_connect_time;
 static qboolean hwcl_received_packet;
 static int hwcl_protocol;
 static int hwcl_servercount;
+static int hwcl_entity_sequence = -1;
 
 /* This is deliberately protocol state rather than cl: Hexen II's cl is tied
  * to its qsocket session and renderer.  Keeping the values here lets the
  * eventual adapter map them deliberately instead of corrupting a concurrent
  * Hexen II connection. */
+typedef struct
+{
+	qboolean active;
+	int modelindex;
+	int frame;
+	int colormap;
+	int skinnum;
+	int scale;
+	int drawflags;
+	int abslight;
+	int alpha;
+	int effects;
+	vec3_t origin;
+	vec3_t angles;
+} hwcl_entity_state_t;
+
 static struct
 {
 	double server_time;
 	vec3_t viewangles;
 	int viewentity;
 	int stats[MAX_CL_STATS];
+	hwcl_entity_state_t baselines[HWCL_MAX_ENTITIES];
+	hwcl_entity_state_t entities[HWCL_MAX_ENTITIES];
 } hwcl_server_state;
 
 static void HWCL_StringCmd (const char *command)
@@ -145,6 +165,7 @@ static void HWCL_ParseServerData (void)
 		return;
 	}
 	hwcl_servercount = MSG_ReadLong ();
+	hwcl_entity_sequence = -1;
 	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
 	q_strlcpy (gamedir, MSG_ReadString (), sizeof(gamedir));
 	playernum = MSG_ReadByte ();
@@ -161,75 +182,117 @@ static void HWCL_ParseServerData (void)
 	HWCL_StringCmd (va ("soundlist %d 0", hwcl_servercount));
 }
 
-/* Signon buffers contain baseline records before their svc_stufftext request.
- * Consume their wire representation now; retaining baselines for entity delta
- * reconstruction belongs with the client-state adapter. */
-static void HWCL_SkipBaseline (void)
+/* Signon buffers contain baseline records.  Keep them because a full packet
+ * delta-compresses each entity from its baseline. */
+static void HWCL_ParseBaseline (void)
 {
+	hwcl_entity_state_t *state;
+	int entitynum;
 	int i;
 
-	MSG_ReadShort (); /* entity number */
-	MSG_ReadShort (); /* model */
-	for (i = 0; i < 6; i++)
-		MSG_ReadByte (); /* frame through absolute light */
+	entitynum = MSG_ReadShort ();
+	if (entitynum < 0 || entitynum >= HWCL_MAX_ENTITIES)
+	{
+		/* Consume the record without indexing outside our protocol state. */
+		MSG_ReadShort ();
+		for (i = 0; i < 6; i++) MSG_ReadByte ();
+		for (i = 0; i < 3; i++) { MSG_ReadCoord (); MSG_ReadAngle (); }
+		return;
+	}
+	state = &hwcl_server_state.baselines[entitynum];
+	memset (state, 0, sizeof(*state));
+	state->active = true;
+	state->modelindex = MSG_ReadShort ();
+	state->frame = MSG_ReadByte ();
+	state->colormap = MSG_ReadByte ();
+	state->skinnum = MSG_ReadByte ();
+	state->scale = MSG_ReadByte ();
+	state->drawflags = MSG_ReadByte ();
+	state->abslight = MSG_ReadByte ();
 	for (i = 0; i < 3; i++)
 	{
-		MSG_ReadCoord ();
-		MSG_ReadAngle ();
+		state->origin[i] = MSG_ReadCoord ();
+		state->angles[i] = MSG_ReadAngle ();
 	}
 }
 
-/* Consume an entity delta without retaining it.  This keeps the packet stream
- * synchronised until the state adapter can map these records to Hexenwail's
- * client entities. */
-static void HWCL_SkipEntityDelta (int bits)
+static void HWCL_ParseEntityDelta (const hwcl_entity_state_t *from,
+		hwcl_entity_state_t *to, int bits)
 {
-	/* The low nine bits are the entity number, not flags. */
-	bits &= ~511;
-	if (bits & (1 << 15))
-		bits |= MSG_ReadByte ();
-	if (bits & (1 << 7))
-		bits |= MSG_ReadByte () << 16;
+	bits &= ~511; /* low nine bits are the entity number */
+	*to = *from;
+	if (bits & (1 << 15)) bits |= MSG_ReadByte ();
+	if (bits & (1 << 7)) bits |= MSG_ReadByte () << 16;
 	if (bits & (1 << 16))
-	{
-		if (bits & (1 << 6))
-			MSG_ReadShort ();
-		else
-			MSG_ReadByte ();
-	}
-	if (bits & (1 << 13)) MSG_ReadByte ();
-	if (bits & (1 << 3)) MSG_ReadByte ();
-	if (bits & (1 << 4)) MSG_ReadByte ();
-	if (bits & (1 << 18)) MSG_ReadByte ();
-	if (bits & (1 << 5)) MSG_ReadLong ();
-	if (bits & (1 << 9)) MSG_ReadCoord ();
-	if (bits & (1 << 0)) MSG_ReadAngle ();
-	if (bits & (1 << 10)) MSG_ReadCoord ();
-	if (bits & (1 << 12)) MSG_ReadAngle ();
-	if (bits & (1 << 11)) MSG_ReadCoord ();
-	if (bits & (1 << 1)) MSG_ReadAngle ();
-	if (bits & (1 << 2)) MSG_ReadByte ();
-	if (bits & (1 << 19)) MSG_ReadByte ();
-	if (bits & (1 << 17)) MSG_ReadShort ();
-	if (bits & (1 << 20)) MSG_ReadByte ();
+		to->modelindex = (bits & (1 << 6)) ? MSG_ReadShort () : MSG_ReadByte ();
+	if (bits & (1 << 13)) to->frame = MSG_ReadByte ();
+	if (bits & (1 << 3)) to->colormap = MSG_ReadByte ();
+	if (bits & (1 << 4)) to->skinnum = MSG_ReadByte ();
+	if (bits & (1 << 18)) to->drawflags = MSG_ReadByte ();
+	if (bits & (1 << 5)) to->effects = MSG_ReadLong ();
+	if (bits & (1 << 9)) to->origin[0] = MSG_ReadCoord ();
+	if (bits & (1 << 0)) to->angles[0] = MSG_ReadAngle ();
+	if (bits & (1 << 10)) to->origin[1] = MSG_ReadCoord ();
+	if (bits & (1 << 12)) to->angles[1] = MSG_ReadAngle ();
+	if (bits & (1 << 11)) to->origin[2] = MSG_ReadCoord ();
+	if (bits & (1 << 1)) to->angles[2] = MSG_ReadAngle ();
+	if (bits & (1 << 2)) to->scale = MSG_ReadByte ();
+	if (bits & (1 << 19)) to->abslight = MSG_ReadByte ();
+	if (bits & (1 << 17)) MSG_ReadShort (); /* sound index, routed later */
+	if (bits & (1 << 20)) to->alpha = MSG_ReadByte (); /* protocol 100 */
+	to->active = true;
 }
 
-static void HWCL_SkipPacketEntities (qboolean delta)
+static void HWCL_ParsePacketEntities (qboolean delta)
 {
+	hwcl_entity_state_t discard = {0};
 	int bits;
+	int entitynum;
+	int source = -1;
+	qboolean apply;
 
 	if (delta)
-		MSG_ReadByte (); /* source sequence */
+	{
+		source = MSG_ReadByte ();
+		apply = hwcl_entity_sequence >= 0 &&
+			source == (hwcl_entity_sequence & 255);
+	}
+	else
+	{
+		apply = true;
+		memset (hwcl_server_state.entities, 0, sizeof(hwcl_server_state.entities));
+	}
 	for (;;)
 	{
 		bits = (unsigned short)MSG_ReadShort ();
-		if (!bits || msg_badread)
+		if (msg_badread)
 			return;
-		if (!(bits & (1 << 14))) /* U_REMOVE has no payload */
-			HWCL_SkipEntityDelta (bits);
+		if (!bits)
+			break;
+		entitynum = bits & 511;
+		if (entitynum >= HWCL_MAX_ENTITIES)
+		{
+			if (!(bits & (1 << 14)))
+				HWCL_ParseEntityDelta (&discard, &discard, bits);
+			continue;
+		}
+		if (bits & (1 << 14))
+		{
+			if (apply)
+				hwcl_server_state.entities[entitynum].active = false;
+			continue;
+		}
+		if (apply)
+			HWCL_ParseEntityDelta (delta ? &hwcl_server_state.entities[entitynum] :
+					&hwcl_server_state.baselines[entitynum],
+					&hwcl_server_state.entities[entitynum], bits);
+		else
+			HWCL_ParseEntityDelta (&discard, &discard, bits);
 		if (msg_badread)
 			return;
 	}
+	if (apply)
+		hwcl_entity_sequence = hwcl_netchan.incoming_sequence;
 }
 
 static void HWCL_SkipUsercmd (void)
@@ -341,10 +404,10 @@ static void HWCL_ParseServerMessage (void)
 			HWCL_SkipPlayerInfo ();
 			break;
 		case HW_SVC_PACKETENTITIES:
-			HWCL_SkipPacketEntities (false);
+			HWCL_ParsePacketEntities (false);
 			break;
 		case HW_SVC_DELTAPACKETENTITIES:
-			HWCL_SkipPacketEntities (true);
+			HWCL_ParsePacketEntities (true);
 			break;
 		case HW_SVC_UPDATEDMINFO:
 			MSG_ReadByte ();
@@ -367,7 +430,7 @@ static void HWCL_ParseServerMessage (void)
 			HWCL_ParsePrecacheList (true);
 			break;
 		case HW_SVC_SPAWNBASELINE:
-			HWCL_SkipBaseline ();
+			HWCL_ParseBaseline ();
 			break;
 		case HW_SVC_STUFFTEXT:
 			text = MSG_ReadString ();
@@ -462,6 +525,7 @@ void HWCL_Disconnect (void)
 
 	hwcl_protocol = 0;
 	hwcl_servercount = 0;
+	hwcl_entity_sequence = -1;
 	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
 	if (hwcl_state == hwcl_connected)
 	{

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -21,9 +21,13 @@
 #define HW_PROTOCOL_VERSION 25
 #define HW_PROTOCOL_VERSION_EXT 26
 #define HW_PROTOCOL_VERSION_HEXENWAIL_1 100
+#define HW_SVC_DISCONNECT 2
+#define HW_SVC_UPDATESTAT 3
+#define HW_SVC_SETVIEW 5
 #define HW_SVC_TIME 7
 #define HW_SVC_PRINT 8
 #define HW_SVC_STUFFTEXT 9
+#define HW_SVC_SETANGLE 10
 #define HW_SVC_SERVERDATA 11
 #define HW_SVC_LIGHTSTYLE 12
 #define HW_SVC_SPAWNBASELINE 22
@@ -56,6 +60,18 @@ static double hwcl_connect_time;
 static qboolean hwcl_received_packet;
 static int hwcl_protocol;
 static int hwcl_servercount;
+
+/* This is deliberately protocol state rather than cl: Hexen II's cl is tied
+ * to its qsocket session and renderer.  Keeping the values here lets the
+ * eventual adapter map them deliberately instead of corrupting a concurrent
+ * Hexen II connection. */
+static struct
+{
+	double server_time;
+	vec3_t viewangles;
+	int viewentity;
+	int stats[MAX_CL_STATS];
+} hwcl_server_state;
 
 static void HWCL_StringCmd (const char *command)
 {
@@ -129,6 +145,7 @@ static void HWCL_ParseServerData (void)
 		return;
 	}
 	hwcl_servercount = MSG_ReadLong ();
+	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
 	q_strlcpy (gamedir, MSG_ReadString (), sizeof(gamedir));
 	playernum = MSG_ReadByte ();
 	q_strlcpy (levelname, MSG_ReadString (), sizeof(levelname));
@@ -271,11 +288,30 @@ static void HWCL_ParseServerMessage (void)
 			if (!msg_badread)
 				Con_Printf ("%s", text);
 			break;
+		case HW_SVC_DISCONNECT:
+			Con_Printf ("HexenWorld server disconnected.\n");
+			HWCL_Disconnect ();
+			return;
+		case HW_SVC_UPDATESTAT:
+			command = MSG_ReadByte ();
+			if (command >= 0 && command < MAX_CL_STATS)
+				hwcl_server_state.stats[command] = MSG_ReadByte ();
+			else
+				MSG_ReadByte ();
+			break;
+		case HW_SVC_SETVIEW:
+			hwcl_server_state.viewentity = MSG_ReadShort ();
+			break;
 		case HW_SVC_SERVERDATA:
 			HWCL_ParseServerData ();
 			break;
 		case HW_SVC_TIME:
-			MSG_ReadFloat ();
+			hwcl_server_state.server_time = MSG_ReadFloat ();
+			break;
+		case HW_SVC_SETANGLE:
+			hwcl_server_state.viewangles[0] = MSG_ReadAngle ();
+			hwcl_server_state.viewangles[1] = MSG_ReadAngle ();
+			hwcl_server_state.viewangles[2] = MSG_ReadAngle ();
 			break;
 		case HW_SVC_LIGHTSTYLE:
 			MSG_ReadByte ();
@@ -290,8 +326,11 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadFloat ();
 			break;
 		case HW_SVC_UPDATESTATLONG:
-			MSG_ReadByte ();
-			MSG_ReadLong ();
+			command = MSG_ReadByte ();
+			if (command >= 0 && command < MAX_CL_STATS)
+				hwcl_server_state.stats[command] = MSG_ReadLong ();
+			else
+				MSG_ReadLong ();
 			break;
 		case HW_SVC_UPDATEUSERINFO:
 			MSG_ReadByte ();
@@ -423,6 +462,7 @@ void HWCL_Disconnect (void)
 
 	hwcl_protocol = 0;
 	hwcl_servercount = 0;
+	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
 	if (hwcl_state == hwcl_connected)
 	{
 		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -15,6 +15,18 @@
 #define HW_A2C_PRINT 'n'
 #define HW_CLC_STRINGCMD 4
 
+/* Keep this protocol namespace separate from Hexen II's protocol.h, which is
+ * already included through quakedef.h. */
+#define HW_OLD_PROTOCOL_VERSION 24
+#define HW_PROTOCOL_VERSION 25
+#define HW_PROTOCOL_VERSION_EXT 26
+#define HW_PROTOCOL_VERSION_HEXENWAIL_1 100
+#define HW_SVC_PRINT 8
+#define HW_SVC_STUFFTEXT 9
+#define HW_SVC_SERVERDATA 11
+#define HW_SVC_MODELLIST 45
+#define HW_SVC_SOUNDLIST 46
+
 typedef enum
 {
 	hwcl_disconnected,
@@ -28,6 +40,141 @@ static netadr_t hwcl_server;
 static netchan_t hwcl_netchan;
 static double hwcl_connect_time;
 static qboolean hwcl_received_packet;
+static int hwcl_protocol;
+static int hwcl_servercount;
+
+static void HWCL_StringCmd (const char *command)
+{
+	MSG_WriteByte (&hwcl_netchan.message, HW_CLC_STRINGCMD);
+	MSG_WriteString (&hwcl_netchan.message, command);
+}
+
+static qboolean HWCL_ValidProtocol (int protocol)
+{
+	return protocol == HW_OLD_PROTOCOL_VERSION ||
+		protocol == HW_PROTOCOL_VERSION ||
+		protocol == HW_PROTOCOL_VERSION_EXT ||
+		protocol == HW_PROTOCOL_VERSION_HEXENWAIL_1;
+}
+
+/* Consume a chunked (protocol 26+) or classic precache list.  Asset loading
+ * remains a later integration layer; consuming the lists here is still
+ * important because it advances the reliable signon handshake. */
+static void HWCL_ParsePrecacheList (qboolean models)
+{
+	int index = 0;
+	const char *entry;
+
+	if (hwcl_protocol >= HW_PROTOCOL_VERSION_EXT)
+		index = MSG_ReadLong ();
+	for (;;)
+	{
+		entry = MSG_ReadString ();
+		if (!entry[0] || msg_badread)
+			break;
+		index++;
+	}
+	if (msg_badread)
+		return;
+
+	if (hwcl_protocol >= HW_PROTOCOL_VERSION_EXT)
+	{
+		index = MSG_ReadLong ();
+		if (msg_badread)
+			return;
+		if (index)
+		{
+			HWCL_StringCmd (va ("%slist %d %d", models ? "model" : "sound",
+					hwcl_servercount, index));
+			return;
+		}
+	}
+
+	if (models)
+	{
+		Con_Printf ("HexenWorld precache lists received; requesting signon.\n");
+		HWCL_StringCmd (va ("prespawn %d 0", hwcl_servercount));
+	}
+	else
+		HWCL_StringCmd (va ("modellist %d 0", hwcl_servercount));
+}
+
+static void HWCL_ParseServerData (void)
+{
+	int i;
+	int playernum;
+	char gamedir[MAX_QPATH];
+	char levelname[1024];
+
+	hwcl_protocol = MSG_ReadLong ();
+	if (!HWCL_ValidProtocol (hwcl_protocol))
+	{
+		Con_Printf ("HexenWorld server returned unsupported protocol %d.\n",
+				hwcl_protocol);
+		HWCL_Disconnect ();
+		return;
+	}
+	hwcl_servercount = MSG_ReadLong ();
+	q_strlcpy (gamedir, MSG_ReadString (), sizeof(gamedir));
+	playernum = MSG_ReadByte ();
+	q_strlcpy (levelname, MSG_ReadString (), sizeof(levelname));
+	if (hwcl_protocol >= HW_PROTOCOL_VERSION)
+		for (i = 0; i < 10; i++)
+			MSG_ReadFloat ();
+	if (msg_badread)
+		return;
+
+	Con_Printf ("HexenWorld protocol %d, game %s, level %s (player %d%s).\n",
+			hwcl_protocol, gamedir, levelname, playernum & 127,
+			(playernum & 128) ? ", spectator" : "");
+	HWCL_StringCmd (va ("soundlist %d 0", hwcl_servercount));
+}
+
+static void HWCL_ParseServerMessage (void)
+{
+	int command;
+	const char *text;
+
+	while (msg_readcount < hw_net_message.cursize)
+	{
+		command = MSG_ReadByte ();
+		switch (command)
+		{
+		case HW_SVC_PRINT:
+			MSG_ReadByte (); /* print level */
+			text = MSG_ReadString ();
+			if (!msg_badread)
+				Con_Printf ("%s", text);
+			break;
+		case HW_SVC_SERVERDATA:
+			HWCL_ParseServerData ();
+			break;
+		case HW_SVC_SOUNDLIST:
+			HWCL_ParsePrecacheList (false);
+			break;
+		case HW_SVC_MODELLIST:
+			HWCL_ParsePrecacheList (true);
+			break;
+		case HW_SVC_STUFFTEXT:
+			text = MSG_ReadString ();
+			if (!msg_badread)
+				Con_DPrintf ("HexenWorld server command: %s", text);
+			break;
+		default:
+			/* Do not desynchronise the reader by guessing unknown message sizes.
+			 * Baselines, entities, and presentation messages are parsed by the
+			 * next client-state adapter layer. */
+			Con_DPrintf ("HexenWorld server message %d awaits state adapter.\n",
+					command);
+			return;
+		}
+		if (msg_badread)
+		{
+			Con_Printf ("Malformed HexenWorld server message.\n");
+			return;
+		}
+	}
+}
 
 static void HWCL_InitNet (void)
 {
@@ -83,6 +230,8 @@ void HWCL_Disconnect (void)
 {
 	static const byte drop[] = {HW_CLC_STRINGCMD, 'd', 'r', 'o', 'p', 0};
 
+	hwcl_protocol = 0;
+	hwcl_servercount = 0;
 	if (hwcl_state == hwcl_connected)
 	{
 		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);
@@ -143,14 +292,13 @@ void HWCL_Frame (void)
 		if (!HWNetchan_Process (&hwcl_netchan))
 			continue;
 
-		/* The channel is live.  Server-message parsing is the next protocol
-		 * layer; keep acknowledging packets so reliable setup can progress. */
 		if (!hwcl_received_packet)
 		{
 			Con_Printf ("HexenWorld netchan established (%d payload bytes).\n",
 					hw_net_message.cursize - msg_readcount);
 			hwcl_received_packet = true;
 		}
+		HWCL_ParseServerMessage ();
 	}
 
 	/* Drive acknowledgements and reliable retransmission even when the server

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -34,6 +34,7 @@
 #define HW_SVC_LIGHTSTYLE 12
 #define HW_SVC_UPDATEFRAGS 14
 #define HW_SVC_STOPSOUND 16
+#define HW_SVC_PARTICLE 18
 #define HW_SVC_SPAWNBASELINE 22
 #define HW_SVC_CENTERPRINT 26
 #define HW_SVC_KILLEDMONSTER 27
@@ -60,7 +61,12 @@
 #define HW_SVC_MAXSPEED 49
 #define HW_SVC_ENTGRAVITY 50
 #define HW_SVC_UPDATE_INV 58
+#define HW_SVC_PARTICLE2 59
+#define HW_SVC_PARTICLE3 60
+#define HW_SVC_PARTICLE4 61
 #define HW_SVC_MIDI_NAME 65
+#define HW_SVC_RAINEFFECT 66
+#define HW_SVC_PACKMISSILE 67
 #define HW_SVC_TARGETUPDATE 69
 #define HW_SVC_SOUND_UPDATE_POS 71
 #define HW_SVC_UPDATE_PIV 72
@@ -397,6 +403,71 @@ static void HWCL_SkipAngles (int count)
 		MSG_ReadAngle ();
 }
 
+static void HWCL_SkipFloats (int count)
+{
+	int i;
+
+	for (i = 0; i < count; i++)
+		MSG_ReadFloat ();
+}
+
+static void HWCL_ParseParticle (void)
+{
+	HWCL_SkipCoords (3);
+	MSG_ReadChar ();
+	MSG_ReadChar ();
+	MSG_ReadChar ();
+	MSG_ReadByte (); /* count */
+	MSG_ReadByte (); /* color */
+}
+
+static void HWCL_ParseParticle2 (void)
+{
+	HWCL_SkipCoords (3);
+	HWCL_SkipFloats (6); /* dmin, dmax */
+	MSG_ReadShort (); /* color */
+	MSG_ReadByte (); /* count */
+	MSG_ReadByte (); /* effect */
+}
+
+static void HWCL_ParseParticle3 (void)
+{
+	HWCL_SkipCoords (3);
+	MSG_ReadByte (); /* box x */
+	MSG_ReadByte (); /* box y */
+	MSG_ReadByte (); /* box z */
+	MSG_ReadShort (); /* color */
+	MSG_ReadByte (); /* count */
+	MSG_ReadByte (); /* effect */
+}
+
+static void HWCL_ParseParticle4 (void)
+{
+	HWCL_SkipCoords (3);
+	MSG_ReadByte (); /* radius */
+	MSG_ReadShort (); /* color */
+	MSG_ReadByte (); /* count */
+	MSG_ReadByte (); /* effect */
+}
+
+static void HWCL_ParseRainEffect (void)
+{
+	HWCL_SkipCoords (6); /* origin, size */
+	HWCL_SkipAngles (2); /* x/y direction */
+	MSG_ReadShort (); /* color */
+	MSG_ReadShort (); /* count */
+}
+
+static void HWCL_ParsePackedMissiles (void)
+{
+	int count;
+	int i;
+
+	count = MSG_ReadByte ();
+	for (i = 0; i < count * 5; i++)
+		MSG_ReadByte ();
+}
+
 static void HWCL_ParseInventoryUpdate (void)
 {
 	unsigned int sc1 = 0;
@@ -568,6 +639,9 @@ static void HWCL_ParseServerMessage (void)
 		case HW_SVC_STOPSOUND:
 			MSG_ReadShort ();
 			break;
+		case HW_SVC_PARTICLE:
+			HWCL_ParseParticle ();
+			break;
 		case HW_SVC_CENTERPRINT:
 			MSG_ReadString ();
 			break;
@@ -643,6 +717,21 @@ static void HWCL_ParseServerMessage (void)
 			break;
 		case HW_SVC_UPDATE_INV:
 			HWCL_ParseInventoryUpdate ();
+			break;
+		case HW_SVC_PARTICLE2:
+			HWCL_ParseParticle2 ();
+			break;
+		case HW_SVC_PARTICLE3:
+			HWCL_ParseParticle3 ();
+			break;
+		case HW_SVC_PARTICLE4:
+			HWCL_ParseParticle4 ();
+			break;
+		case HW_SVC_RAINEFFECT:
+			HWCL_ParseRainEffect ();
+			break;
+		case HW_SVC_PACKMISSILE:
+			HWCL_ParsePackedMissiles ();
 			break;
 		case HW_SVC_TARGETUPDATE:
 			MSG_ReadByte ();

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -21,12 +21,22 @@
 #define HW_PROTOCOL_VERSION 25
 #define HW_PROTOCOL_VERSION_EXT 26
 #define HW_PROTOCOL_VERSION_HEXENWAIL_1 100
+#define HW_SVC_TIME 7
 #define HW_SVC_PRINT 8
 #define HW_SVC_STUFFTEXT 9
 #define HW_SVC_SERVERDATA 11
+#define HW_SVC_LIGHTSTYLE 12
 #define HW_SVC_SPAWNBASELINE 22
+#define HW_SVC_UPDATEPING 36
+#define HW_SVC_UPDATEENTERTIME 37
+#define HW_SVC_UPDATESTATLONG 38
+#define HW_SVC_UPDATEUSERINFO 40
 #define HW_SVC_MODELLIST 45
 #define HW_SVC_SOUNDLIST 46
+#define HW_SVC_UPDATEDMINFO 75
+#define HW_SVC_UPDATESIEGEINFO 76
+#define HW_SVC_UPDATESIEGETEAM 77
+#define HW_SVC_UPDATESIEGELOSSES 78
 
 typedef enum
 {
@@ -168,6 +178,44 @@ static void HWCL_ParseServerMessage (void)
 		case HW_SVC_SERVERDATA:
 			HWCL_ParseServerData ();
 			break;
+		case HW_SVC_TIME:
+			MSG_ReadFloat ();
+			break;
+		case HW_SVC_LIGHTSTYLE:
+			MSG_ReadByte ();
+			MSG_ReadString ();
+			break;
+		case HW_SVC_UPDATEPING:
+			MSG_ReadByte ();
+			MSG_ReadShort ();
+			break;
+		case HW_SVC_UPDATEENTERTIME:
+			MSG_ReadByte ();
+			MSG_ReadFloat ();
+			break;
+		case HW_SVC_UPDATESTATLONG:
+			MSG_ReadByte ();
+			MSG_ReadLong ();
+			break;
+		case HW_SVC_UPDATEUSERINFO:
+			MSG_ReadByte ();
+			MSG_ReadLong ();
+			MSG_ReadString ();
+			break;
+		case HW_SVC_UPDATEDMINFO:
+			MSG_ReadByte ();
+			MSG_ReadShort ();
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_UPDATESIEGEINFO:
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_UPDATESIEGETEAM:
+		case HW_SVC_UPDATESIEGELOSSES:
+			MSG_ReadByte ();
+			MSG_ReadByte ();
+			break;
 		case HW_SVC_SOUNDLIST:
 			HWCL_ParsePrecacheList (false);
 			break;
@@ -189,6 +237,13 @@ static void HWCL_ParseServerMessage (void)
 					!q_strncasecmp (text, "cmd spawn ", 10) ||
 					!q_strncasecmp (text, "cmd begin", 9))
 					HWCL_StringCmd (text + 4);
+				else if (!q_strcasecmp (text, "skins\n"))
+				{
+					/* Skin download/translation is not wired up yet, but it must
+					 * not hold the transport handshake hostage. */
+					HWCL_StringCmd (va ("begin %d", hwcl_servercount));
+					Con_Printf ("HexenWorld signon complete; awaiting state adapter.\n");
+				}
 			}
 			break;
 		default:

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -13,6 +13,7 @@
 #define HW_PORT_SERVER 26950
 #define HW_S2C_CONNECTION 'j'
 #define HW_A2C_PRINT 'n'
+#define HW_CLC_MOVE 3
 #define HW_CLC_STRINGCMD 4
 
 /* Keep this protocol namespace separate from Hexen II's protocol.h, which is
@@ -144,10 +145,69 @@ static struct
 	hwcl_entity_state_t players[HWCL_MAX_CLIENTS];
 } hwcl_server_state;
 
+typedef struct
+{
+	vec3_t angles;
+	int forwardmove;
+	int sidemove;
+	int upmove;
+	int buttons;
+	int impulse;
+	int msec;
+} hwcl_usercmd_t;
+
+static hwcl_usercmd_t hwcl_cmd_history[3];
+static qboolean hwcl_have_cmd_history;
+
 static void HWCL_StringCmd (const char *command)
 {
 	MSG_WriteByte (&hwcl_netchan.message, HW_CLC_STRINGCMD);
 	MSG_WriteString (&hwcl_netchan.message, command);
+}
+
+static void HWCL_WriteAngle16 (sizebuf_t *buf, float angle)
+{
+	int value;
+
+	if (angle >= 0)
+		value = (int)(angle * (65536.0f / 360.0f) + 0.5f);
+	else
+		value = (int)(angle * (65536.0f / 360.0f) - 0.5f);
+	MSG_WriteShort (buf, value & 65535);
+}
+
+static int HWCL_QuantizeMove (int move)
+{
+	if (move > 508)
+		return 127;
+	if (move < -512)
+		return -128;
+	return (int)(move * 0.25f);
+}
+
+static void HWCL_WriteUsercmd (sizebuf_t *buf, const hwcl_usercmd_t *cmd)
+{
+	int bits = 0;
+
+	if (cmd->angles[0]) bits |= (1 << 0);
+	if (cmd->angles[2]) bits |= (1 << 1);
+	if (cmd->forwardmove) bits |= (1 << 2);
+	if (cmd->sidemove) bits |= (1 << 3);
+	if (cmd->upmove) bits |= (1 << 4);
+	if (cmd->buttons) bits |= (1 << 5);
+	if (cmd->impulse) bits |= (1 << 6);
+	if (cmd->msec) bits |= (1 << 7);
+
+	MSG_WriteByte (buf, bits);
+	if (bits & (1 << 0)) HWCL_WriteAngle16 (buf, cmd->angles[0]);
+	HWCL_WriteAngle16 (buf, cmd->angles[1]);
+	if (bits & (1 << 1)) HWCL_WriteAngle16 (buf, cmd->angles[2]);
+	if (bits & (1 << 2)) MSG_WriteChar (buf, HWCL_QuantizeMove (cmd->forwardmove));
+	if (bits & (1 << 3)) MSG_WriteChar (buf, HWCL_QuantizeMove (cmd->sidemove));
+	if (bits & (1 << 4)) MSG_WriteChar (buf, HWCL_QuantizeMove (cmd->upmove));
+	if (bits & (1 << 5)) MSG_WriteByte (buf, cmd->buttons);
+	if (bits & (1 << 6)) MSG_WriteByte (buf, cmd->impulse);
+	if (bits & (1 << 7)) MSG_WriteByte (buf, cmd->msec);
 }
 
 static qboolean HWCL_ValidProtocol (int protocol)
@@ -643,6 +703,7 @@ static void HWCL_ParseServerMessage (void)
 			hwcl_server_state.viewangles[0] = MSG_ReadAngle ();
 			hwcl_server_state.viewangles[1] = MSG_ReadAngle ();
 			hwcl_server_state.viewangles[2] = MSG_ReadAngle ();
+			VectorCopy (hwcl_server_state.viewangles, cl.viewangles);
 			break;
 		case HW_SVC_LIGHTSTYLE:
 			MSG_ReadByte ();
@@ -829,6 +890,7 @@ static void HWCL_ParseServerMessage (void)
 					/* Skin download/translation is not wired up yet, but it must
 					 * not hold the transport handshake hostage. */
 					HWCL_StringCmd (va ("begin %d", hwcl_servercount));
+					cls.signon = SIGNONS;
 					Con_Printf ("HexenWorld signon complete; awaiting state adapter.\n");
 				}
 			}
@@ -899,6 +961,61 @@ qboolean HWCL_Active (void)
 	return hwcl_state != hwcl_disconnected;
 }
 
+void HWCL_SendCmd (const usercmd_t *cmd)
+{
+	hwcl_usercmd_t current;
+	hwcl_usercmd_t oldest;
+	hwcl_usercmd_t oldcmd;
+	sizebuf_t buf;
+	byte data[128];
+	int i;
+	int msec;
+
+	if (hwcl_state != hwcl_connected || hwcl_protocol == 0 ||
+			!HWNetchan_CanPacket (&hwcl_netchan))
+		return;
+
+	memset (&current, 0, sizeof(current));
+	VectorCopy (cl.viewangles, current.angles);
+	current.forwardmove = (int)cmd->forwardmove;
+	current.sidemove = (int)cmd->sidemove;
+	current.upmove = (int)cmd->upmove;
+	current.buttons = CL_GetButtonBits ();
+	current.impulse = CL_GetImpulse ();
+	msec = (int)(host_frametime * 1000.0 + 0.5);
+	if (msec < 1)
+		msec = 1;
+	if (msec > 255)
+		msec = 255;
+	current.msec = msec;
+
+	if (!hwcl_have_cmd_history)
+	{
+		hwcl_cmd_history[0] = current;
+		hwcl_cmd_history[1] = current;
+		hwcl_cmd_history[2] = current;
+		hwcl_have_cmd_history = true;
+	}
+
+	oldest = hwcl_cmd_history[0];
+	oldcmd = hwcl_cmd_history[1];
+	/* Impulses are one-shot commands.  Replaying them from the two backup
+	 * commands would fire a weapon or select an item multiple times. */
+	oldest.impulse = 0;
+	oldcmd.impulse = 0;
+
+	SZ_Init (&buf, data, sizeof(data));
+	MSG_WriteByte (&buf, HW_CLC_MOVE);
+	HWCL_WriteUsercmd (&buf, &oldest);
+	HWCL_WriteUsercmd (&buf, &oldcmd);
+	HWCL_WriteUsercmd (&buf, &current);
+	HWNetchan_Transmit (&hwcl_netchan, buf.cursize, buf.data);
+
+	for (i = 0; i < 2; i++)
+		hwcl_cmd_history[i] = hwcl_cmd_history[i + 1];
+	hwcl_cmd_history[2] = current;
+}
+
 void HWCL_Disconnect (void)
 {
 	static const byte drop[] = {HW_CLC_STRINGCMD, 'd', 'r', 'o', 'p', 0};
@@ -906,7 +1023,10 @@ void HWCL_Disconnect (void)
 	hwcl_protocol = 0;
 	hwcl_servercount = 0;
 	hwcl_entity_sequence = -1;
+	hwcl_have_cmd_history = false;
+	memset (hwcl_cmd_history, 0, sizeof(hwcl_cmd_history));
 	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
+	cls.signon = 0;
 	if (hwcl_state == hwcl_connected)
 	{
 		HWNetchan_Transmit (&hwcl_netchan, sizeof(drop), (byte *)drop);

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -200,6 +200,8 @@ static struct
 	int cdtrack;
 	int chokecount;
 	int piv;
+	int playerclass[HWCL_MAX_CLIENTS];
+	int playerlevel[HWCL_MAX_CLIENTS];
 	float maxspeed;
 	float entgravity;
 	char midi_name[MAX_QPATH];
@@ -221,6 +223,13 @@ typedef struct
 
 static hwcl_usercmd_t hwcl_cmd_history[3];
 static qboolean hwcl_have_cmd_history;
+static char hwcl_model_names[MAX_MODELS][MAX_QPATH];
+static char hwcl_sound_names[MAX_SOUNDS][MAX_QPATH];
+static int hwcl_model_count;
+static int hwcl_sound_count;
+static int hwcl_playernum;
+
+extern qmodel_t *player_models[MAX_PLAYER_CLASS];
 
 static void HWCL_StringCmd (const char *command)
 {
@@ -281,21 +290,85 @@ static qboolean HWCL_ValidProtocol (int protocol)
 		protocol == HW_PROTOCOL_VERSION_HEXENWAIL_1;
 }
 
-/* Consume a chunked (protocol 26+) or classic precache list.  Asset loading
- * remains a later integration layer; consuming the lists here is still
- * important because it advances the reliable signon handshake. */
+static void HWCL_LoadModels (void)
+{
+	static const char *player_names[MAX_PLAYER_CLASS] = {
+		"models/paladin.mdl", "models/crusader.mdl", "models/necro.mdl",
+		"models/assassin.mdl", "models/succubus.mdl"
+	};
+	qmodel_t *model;
+	int i;
+
+	memset (cl.model_precache, 0, sizeof(cl.model_precache));
+	for (i = 1; i < hwcl_model_count; i++)
+	{
+		if (!hwcl_model_names[i][0])
+			continue;
+		model = Mod_ForName (hwcl_model_names[i], false);
+		if (!model)
+		{
+			Con_DPrintf ("HexenWorld model %d unavailable: %s\n", i,
+					hwcl_model_names[i]);
+			continue;
+		}
+		cl.model_precache[i] = model;
+	}
+
+	for (i = 0; i < MAX_PLAYER_CLASS; i++)
+		if (!player_models[i])
+			player_models[i] = Mod_ForName (player_names[i], false);
+
+	if (!cl.model_precache[1])
+	{
+		Con_Printf ("HexenWorld world model unavailable: %s\n",
+				hwcl_model_names[1]);
+		return;
+	}
+
+	cl.worldmodel = cl_entities[0].model = cl.model_precache[1];
+	COM_FileBase (hwcl_model_names[1], cl.mapname, sizeof(cl.mapname));
+	R_NewMap ();
+}
+
+static void HWCL_LoadSounds (void)
+{
+	int i;
+
+	S_ClearPrecache ();
+	memset (cl.sound_precache, 0, sizeof(cl.sound_precache));
+	S_BeginPrecaching ();
+	for (i = 1; i < hwcl_sound_count; i++)
+	{
+		if (hwcl_sound_names[i][0])
+			cl.sound_precache[i] = S_PrecacheSound (hwcl_sound_names[i]);
+	}
+	S_EndPrecaching ();
+	CL_PrecacheTEntSounds ();
+}
+
+/* Consume a chunked (protocol 26+) or classic precache list and retain its
+ * indices.  The chunk command uses zero-based offsets, while wire indices
+ * start at one. */
 static void HWCL_ParsePrecacheList (qboolean models)
 {
-	int index = 0;
+	int index = 1;
+	int next;
 	const char *entry;
 
 	if (hwcl_protocol >= HW_PROTOCOL_VERSION_EXT)
-		index = MSG_ReadLong ();
+		index = MSG_ReadLong () + 1;
 	for (;;)
 	{
 		entry = MSG_ReadString ();
 		if (!entry[0] || msg_badread)
 			break;
+		if (index > 0 && (models ? index < MAX_MODELS : index < MAX_SOUNDS))
+		{
+			if (models)
+				q_strlcpy (hwcl_model_names[index], entry, MAX_QPATH);
+			else
+				q_strlcpy (hwcl_sound_names[index], entry, MAX_QPATH);
+		}
 		index++;
 	}
 	if (msg_badread)
@@ -303,24 +376,30 @@ static void HWCL_ParsePrecacheList (qboolean models)
 
 	if (hwcl_protocol >= HW_PROTOCOL_VERSION_EXT)
 	{
-		index = MSG_ReadLong ();
+		next = MSG_ReadLong ();
 		if (msg_badread)
 			return;
-		if (index)
+		if (next)
 		{
 			HWCL_StringCmd (va ("%slist %d %d", models ? "model" : "sound",
-					hwcl_servercount, index));
+					hwcl_servercount, next));
 			return;
 		}
 	}
 
 	if (models)
 	{
+		hwcl_model_count = index > hwcl_model_count ? index : hwcl_model_count;
+		HWCL_LoadModels ();
 		Con_Printf ("HexenWorld precache lists received; requesting signon.\n");
 		HWCL_StringCmd (va ("prespawn %d 0", hwcl_servercount));
 	}
 	else
+	{
+		hwcl_sound_count = index > hwcl_sound_count ? index : hwcl_sound_count;
+		HWCL_LoadSounds ();
 		HWCL_StringCmd (va ("modellist %d 0", hwcl_servercount));
+	}
 }
 
 static void HWCL_ParseServerData (void)
@@ -346,9 +425,35 @@ static void HWCL_ParseServerData (void)
 	q_strlcpy (levelname, MSG_ReadString (), sizeof(levelname));
 	if (hwcl_protocol >= HW_PROTOCOL_VERSION)
 		for (i = 0; i < 10; i++)
-			MSG_ReadFloat ();
+		{
+			float movevar = MSG_ReadFloat ();
+			if (i == 2)
+				hwcl_server_state.maxspeed = movevar;
+			if (i == 9)
+				hwcl_server_state.entgravity = movevar;
+		}
 	if (msg_badread)
 		return;
+
+	CL_ClearState ();
+	cls.signon = 0;
+	memset (hwcl_model_names, 0, sizeof(hwcl_model_names));
+	memset (hwcl_sound_names, 0, sizeof(hwcl_sound_names));
+	hwcl_model_count = 1;
+	hwcl_sound_count = 1;
+	hwcl_playernum = playernum & 127;
+	q_strlcpy (cl.levelname, levelname, sizeof(cl.levelname));
+	q_strlcpy (cl.mod_name, gamedir, sizeof(cl.mod_name));
+	cl.maxclients = HWCL_MAX_CLIENTS;
+	cl.scores = (scoreboard_t *)Hunk_AllocName (
+			cl.maxclients * sizeof(*cl.scores), "hw_scores");
+	memset (cl.scores, 0, cl.maxclients * sizeof(*cl.scores));
+	cl.gametype = GAME_DEATHMATCH;
+	cl.viewentity = hwcl_playernum + 1;
+	hwcl_server_state.viewentity = cl.viewentity;
+	if (hwcl_playernum >= 0 && hwcl_playernum < HWCL_MAX_CLIENTS)
+		hwcl_server_state.playerclass[hwcl_playernum] =
+			(int)cl_playerclass.value;
 
 	Con_Printf ("HexenWorld protocol %d, game %s, level %s (player %d%s).\n",
 			hwcl_protocol, gamedir, levelname, playernum & 127,
@@ -603,6 +708,35 @@ static void HWCL_ParseNails (void)
 		MSG_ReadByte ();
 }
 
+static const char *HWCL_InfoValue (const char *info, const char *key)
+{
+	static char value[512];
+	char current[512];
+	const char *p = info;
+	int i;
+
+	if (*p == '\\')
+		p++;
+	while (*p)
+	{
+		i = 0;
+		while (*p && *p != '\\' && i < (int)sizeof(current) - 1)
+			current[i++] = *p++;
+		current[i] = 0;
+		if (*p == '\\')
+			p++;
+		i = 0;
+		while (*p && *p != '\\' && i < (int)sizeof(value) - 1)
+			value[i++] = *p++;
+		value[i] = 0;
+		if (!strcmp (current, key))
+			return value;
+		if (*p == '\\')
+			p++;
+	}
+	return "";
+}
+
 static void HWCL_ParseDamage (void)
 {
 	MSG_ReadByte (); /* armor damage */
@@ -839,6 +973,124 @@ static qboolean HWCL_ParseMultiEffect (void)
 	return !msg_badread;
 }
 
+static qmodel_t *HWCL_ModelForEntity (const hwcl_entity_state_t *state,
+		qboolean player)
+{
+	int playerclass;
+
+	if (state->modelindex > 0 && state->modelindex < MAX_MODELS)
+		return cl.model_precache[state->modelindex];
+	if (!player)
+		return NULL;
+
+	playerclass = hwcl_server_state.playerclass[state - hwcl_server_state.players];
+	if (playerclass < 1 || playerclass > MAX_PLAYER_CLASS)
+		playerclass = 1;
+	return player_models[playerclass - 1];
+}
+
+static void HWCL_CopyEntity (int entitynum, const hwcl_entity_state_t *state,
+		qboolean player)
+{
+	entity_t *ent = &cl_entities[entitynum];
+	qmodel_t *model;
+	qboolean was_on;
+	qboolean model_changed;
+
+	model = HWCL_ModelForEntity (state, player);
+	was_on = (ent->baseline.flags & BE_ON) != 0;
+	model_changed = ent->model != model;
+	if (model_changed && ent->efrag)
+		R_RemoveEfrags (ent);
+	if (!was_on || model_changed)
+		ent->forcelink = true;
+
+	ent->baseline.flags = BE_ON;
+	ent->baseline.modelindex = state->modelindex;
+	ent->baseline.frame = state->frame;
+	ent->baseline.colormap = state->colormap;
+	ent->baseline.skin = state->skinnum;
+	ent->baseline.effects = state->effects;
+	ent->baseline.scale = state->scale;
+	ent->baseline.drawflags = state->drawflags;
+	ent->baseline.abslight = state->abslight;
+	ent->baseline.alpha = (byte)state->alpha;
+
+	if (was_on)
+	{
+		VectorCopy (ent->msg_origins[0], ent->msg_origins[1]);
+		VectorCopy (ent->msg_angles[0], ent->msg_angles[1]);
+	}
+	VectorCopy (state->origin, ent->msg_origins[0]);
+	VectorCopy (state->angles, ent->msg_angles[0]);
+	ent->msgtime = cl.mtime[0];
+	ent->model = model;
+	ent->frame = state->frame;
+	ent->colormap = vid.colormap;
+	ent->sourcecolormap = vid.colormap;
+	ent->skinnum = state->skinnum;
+	ent->effects = state->effects;
+	ent->scale = state->scale;
+	ent->drawflags = state->drawflags;
+	ent->abslight = state->abslight;
+	ent->alpha = (byte)state->alpha;
+
+	if (model_changed && model && cl.worldmodel)
+		R_AddEfrags (ent);
+}
+
+static void HWCL_ClearEntity (int entitynum)
+{
+	entity_t *ent = &cl_entities[entitynum];
+
+	if (ent->efrag)
+		R_RemoveEfrags (ent);
+	memset (ent, 0, sizeof(*ent));
+}
+
+void HWCL_ApplyState (void)
+{
+	const hwcl_entity_state_t *state;
+	int i;
+	int highest = 0;
+	int viewentity;
+
+	cl.mtime[1] = cl.mtime[0];
+	cl.mtime[0] = hwcl_server_state.server_time;
+	cl.time = cl.mtime[0];
+	for (i = 0; i < MAX_CL_STATS; i++)
+		cl.stats[i] = hwcl_server_state.stats[i];
+
+	for (i = 1; i < HWCL_MAX_ENTITIES; i++)
+	{
+		if (i <= HWCL_MAX_CLIENTS)
+			state = &hwcl_server_state.players[i - 1];
+		else
+			state = &hwcl_server_state.entities[i];
+
+		if (state->active)
+		{
+			HWCL_CopyEntity (i, state, i <= HWCL_MAX_CLIENTS);
+			highest = i;
+		}
+		else if (cl_entities[i].baseline.flags & BE_ON)
+			HWCL_ClearEntity (i);
+	}
+
+	viewentity = hwcl_server_state.viewentity;
+	if (viewentity < 1 || viewentity >= HWCL_MAX_ENTITIES)
+		viewentity = hwcl_playernum + 1;
+	cl.viewentity = viewentity;
+	if (viewentity <= HWCL_MAX_CLIENTS)
+	{
+		state = &hwcl_server_state.players[viewentity - 1];
+		VectorCopy (state->velocity, cl.velocity);
+	}
+	cl.num_entities = highest + 1;
+	if (cl.num_entities < 1)
+		cl.num_entities = 1;
+}
+
 static void HWCL_ParseInventoryUpdate (void)
 {
 	unsigned int sc1 = 0;
@@ -1005,8 +1257,12 @@ static void HWCL_ParseServerMessage (void)
 			HWCL_ParseSound ();
 			break;
 		case HW_SVC_UPDATEFRAGS:
-			MSG_ReadByte ();
-			MSG_ReadShort ();
+			{
+				int slot = MSG_ReadByte ();
+				int frags = MSG_ReadShort ();
+				if (slot >= 0 && slot < cl.maxclients && cl.scores)
+					cl.scores[slot].frags = frags;
+			}
 			break;
 		case HW_SVC_STOPSOUND:
 			MSG_ReadShort ();
@@ -1065,8 +1321,12 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadShort ();
 			break;
 		case HW_SVC_UPDATEENTERTIME:
-			MSG_ReadByte ();
-			MSG_ReadFloat ();
+			{
+				int slot = MSG_ReadByte ();
+				float entertime = MSG_ReadFloat ();
+				if (slot >= 0 && slot < cl.maxclients && cl.scores)
+					cl.scores[slot].entertime = entertime;
+			}
 			break;
 		case HW_SVC_UPDATESTATLONG:
 			command = MSG_ReadByte ();
@@ -1079,9 +1339,23 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadShort ();
 			break;
 		case HW_SVC_UPDATEUSERINFO:
-			MSG_ReadByte ();
-			MSG_ReadLong ();
-			MSG_ReadString ();
+			{
+				int slot = MSG_ReadByte ();
+				int uid = MSG_ReadLong ();
+				const char *userinfo = MSG_ReadString ();
+				const char *name;
+				(void)uid;
+				if (slot >= 0 && slot < cl.maxclients && cl.scores)
+				{
+					name = HWCL_InfoValue (userinfo, "name");
+					q_strlcpy (cl.scores[slot].name, name,
+							sizeof(cl.scores[slot].name));
+					cl.scores[slot].colors = atoi (
+						HWCL_InfoValue (userinfo, "topcolor")) << 4;
+					cl.scores[slot].colors |= atoi (
+						HWCL_InfoValue (userinfo, "bottomcolor"));
+				}
+			}
 			break;
 		case HW_SVC_DOWNLOAD:
 			HWCL_ParseDownload ();
@@ -1164,8 +1438,15 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadShort ();
 			break;
 		case HW_SVC_UPDATEPCLASS:
-			MSG_ReadByte ();
-			MSG_ReadByte ();
+			{
+				int slot = MSG_ReadByte ();
+				int packed = MSG_ReadByte ();
+				if (slot >= 0 && slot < HWCL_MAX_CLIENTS)
+				{
+					hwcl_server_state.playerclass[slot] = (packed >> 5) & 7;
+					hwcl_server_state.playerlevel[slot] = packed & 31;
+				}
+			}
 			break;
 		case HW_SVC_HASKEY:
 		case HW_SVC_NONEHASKEY:
@@ -1278,6 +1559,8 @@ qboolean HWCL_Connect (const char *host)
 	if (!hwcl_server.port)
 		hwcl_server.port = BigShort (HW_PORT_SERVER);
 
+	CL_ClearState ();
+	cls.state = ca_connected;
 	hwcl_state = hwcl_connecting;
 	HWCL_SendConnectPacket ();
 	return true;
@@ -1362,6 +1645,7 @@ void HWCL_Disconnect (void)
 	}
 	hwcl_state = hwcl_disconnected;
 	hwcl_received_packet = false;
+	cls.state = ca_disconnected;
 }
 
 static void HWCL_ConnectionlessPacket (void)

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -1407,7 +1407,19 @@ static void HWCL_ParseServerMessage (void)
 			HWCL_ParseDownload ();
 			break;
 		case HW_SVC_PLAYERINFO:
-			HWCL_ParsePlayerInfo ();
+			{
+				int slot = hwcl_server_state.viewentity - 1;
+				HWCL_ParsePlayerInfo ();
+				if (slot >= 0 && slot < HWCL_MAX_CLIENTS &&
+					hwcl_server_state.players[slot].active)
+				{
+					entity_t *ent = &cl_entities[cl.viewentity];
+					const hwcl_entity_state_t *state =
+						&hwcl_server_state.players[slot];
+					VectorCopy (state->origin, ent->baseline.origin);
+					ent->baseline.flags |= BE_ON;
+				}
+			}
 			break;
 		case HW_SVC_NAILS:
 			HWCL_ParseNails ();
@@ -1501,10 +1513,12 @@ static void HWCL_ParseServerMessage (void)
 			{
 				int slot = MSG_ReadByte ();
 				int packed = MSG_ReadByte ();
-				if (slot >= 0 && slot < HWCL_MAX_CLIENTS)
+				if (slot >= 0 && slot < HWCL_MAX_CLIENTS && cl.scores)
 				{
 					hwcl_server_state.playerclass[slot] = (packed >> 5) & 7;
 					hwcl_server_state.playerlevel[slot] = packed & 31;
+					cl.scores[slot].playerclass =
+						(float)hwcl_server_state.playerclass[slot];
 				}
 			}
 			break;

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -45,6 +45,7 @@
 #define HW_SVC_UPDATESIEGETEAM 77
 #define HW_SVC_UPDATESIEGELOSSES 78
 #define HWCL_MAX_ENTITIES 768
+#define HWCL_MAX_CLIENTS 32
 
 typedef enum
 {
@@ -74,6 +75,7 @@ typedef struct
 	int frame;
 	int colormap;
 	int skinnum;
+	int weaponframe;
 	int scale;
 	int drawflags;
 	int abslight;
@@ -81,6 +83,7 @@ typedef struct
 	int effects;
 	vec3_t origin;
 	vec3_t angles;
+	vec3_t velocity;
 } hwcl_entity_state_t;
 
 static struct
@@ -91,6 +94,7 @@ static struct
 	int stats[MAX_CL_STATS];
 	hwcl_entity_state_t baselines[HWCL_MAX_ENTITIES];
 	hwcl_entity_state_t entities[HWCL_MAX_ENTITIES];
+	hwcl_entity_state_t players[HWCL_MAX_CLIENTS];
 } hwcl_server_state;
 
 static void HWCL_StringCmd (const char *command)
@@ -310,29 +314,45 @@ static void HWCL_SkipUsercmd (void)
 	if (bits & (1 << 7)) MSG_ReadByte ();
 }
 
-static void HWCL_SkipPlayerInfo (void)
+static void HWCL_ParsePlayerInfo (void)
 {
+	hwcl_entity_state_t discard = {0};
+	hwcl_entity_state_t *state;
 	int flags;
+	int playernum;
 	int i;
 
-	MSG_ReadByte (); /* player slot */
+	playernum = MSG_ReadByte ();
+	state = playernum >= 0 && playernum < HWCL_MAX_CLIENTS ?
+		&hwcl_server_state.players[playernum] : &discard;
 	flags = (unsigned short)MSG_ReadShort ();
+	state->active = true;
 	for (i = 0; i < 3; i++)
-		MSG_ReadCoord ();
-	MSG_ReadByte (); /* frame */
+		state->origin[i] = MSG_ReadCoord ();
+	state->frame = MSG_ReadByte ();
 	if (flags & (1 << 0)) MSG_ReadByte (); /* msec */
 	if (flags & (1 << 1)) HWCL_SkipUsercmd ();
 	for (i = 0; i < 3; i++)
-		if (flags & (1 << (2 + i))) MSG_ReadShort ();
-	if (flags & (1 << 5)) MSG_ReadShort ();
-	if (flags & (1 << 6)) MSG_ReadByte ();
-	if (flags & (1 << 7)) MSG_ReadByte ();
-	if (flags & (1 << 11)) MSG_ReadByte ();
-	if (flags & (1 << 8)) MSG_ReadByte ();
-	if (flags & (1 << 12)) MSG_ReadByte ();
-	if (flags & (1 << 13)) MSG_ReadByte ();
-	if (flags & (1 << 14)) MSG_ReadByte ();
-	if (flags & (1 << 15)) MSG_ReadShort ();
+	{
+		if (flags & (1 << (2 + i)))
+			state->velocity[i] = MSG_ReadShort ();
+		else
+			state->velocity[i] = 0;
+	}
+	if (flags & (1 << 5)) state->modelindex = MSG_ReadShort ();
+	if (flags & (1 << 6)) state->skinnum = MSG_ReadByte ();
+	if (flags & (1 << 7)) state->effects = MSG_ReadByte ();
+	else state->effects = 0;
+	if (flags & (1 << 11)) state->effects |= MSG_ReadByte () << 8;
+	if (flags & (1 << 8)) state->weaponframe = MSG_ReadByte ();
+	else state->weaponframe = 0;
+	if (flags & (1 << 12)) state->drawflags = MSG_ReadByte ();
+	else state->drawflags = 0;
+	if (flags & (1 << 13)) state->scale = MSG_ReadByte ();
+	else state->scale = 0;
+	if (flags & (1 << 14)) state->abslight = MSG_ReadByte ();
+	else state->abslight = 0;
+	if (flags & (1 << 15)) MSG_ReadShort (); /* weapon-channel sound */
 }
 
 static void HWCL_ParseServerMessage (void)
@@ -401,7 +421,7 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadString ();
 			break;
 		case HW_SVC_PLAYERINFO:
-			HWCL_SkipPlayerInfo ();
+			HWCL_ParsePlayerInfo ();
 			break;
 		case HW_SVC_PACKETENTITIES:
 			HWCL_ParsePacketEntities (false);

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -9,6 +9,59 @@
 #include "../hexenworld/shared/net.h"
 #include "../hexenworld/shared/huffman.h"
 
+/* quakedef.h already includes Hexen II's effects.h.  HexenWorld uses the
+ * same names for a different numeric table, so keep the values local to this
+ * protocol reader instead of letting the two headers collide. */
+#undef CE_ACID_MUZZFL
+#define CE_ACID_MUZZFL 58
+#undef CE_FLAMESTREAM
+#define CE_FLAMESTREAM 74
+#undef CE_BLDRN_EXPL
+#define CE_BLDRN_EXPL 57
+#undef CE_ACID_HIT
+#define CE_ACID_HIT 59
+#undef CE_FIREWALL_SMALL
+#define CE_FIREWALL_SMALL 60
+#undef CE_FIREWALL_MEDIUM
+#define CE_FIREWALL_MEDIUM 61
+#undef CE_FIREWALL_LARGE
+#define CE_FIREWALL_LARGE 62
+#undef CE_LBALL_EXPL
+#define CE_LBALL_EXPL 63
+#undef CE_ACID_SPLAT
+#define CE_ACID_SPLAT 64
+#undef CE_ACID_EXPL
+#define CE_ACID_EXPL 65
+#undef CE_FBOOM
+#define CE_FBOOM 66
+#undef CE_BOMB
+#define CE_BOMB 67
+#undef CE_BRN_BOUNCE
+#define CE_BRN_BOUNCE 68
+#undef CE_LSHOCK
+#define CE_LSHOCK 69
+#undef CE_FLAMEWALL
+#define CE_FLAMEWALL 70
+#undef CE_FLAMEWALL2
+#define CE_FLAMEWALL2 71
+#undef CE_ONFIRE
+#define CE_ONFIRE 73
+#define CE_RIPPLE 56
+#define CE_SM_EXPLOSION2 50
+#define CE_HWMISSILESTAR 42
+#define CE_HWEIDOLONSTAR 43
+#define CE_HWSHEEPINATOR 44
+#define CE_TRIPMINE 45
+#define CE_HWBONEBALL 46
+#define CE_HWRAVENSTAFF 47
+#define CE_TRIPMINESTILL 48
+#define CE_SCARABCHAIN 49
+#define CE_HWSPLITFLASH 51
+#define CE_HWXBOWSHOOT 52
+#define CE_HWRAVENPOWER 53
+#define CE_HWDRILLA 54
+#define CE_DEATHBUBBLES 55
+
 #define HW_PORT_CLIENT 26901
 #define HW_PORT_SERVER 26950
 #define HW_S2C_CONNECTION 'j'
@@ -63,14 +116,24 @@
 #define HW_SVC_DELTAPACKETENTITIES 48
 #define HW_SVC_MAXSPEED 49
 #define HW_SVC_ENTGRAVITY 50
+#define HW_SVC_SET_VIEW_TINT 53
+#define HW_SVC_START_EFFECT 54
+#define HW_SVC_END_EFFECT 55
+#define HW_SVC_SET_VIEW_FLAGS 56
+#define HW_SVC_CLEAR_VIEW_FLAGS 57
 #define HW_SVC_UPDATE_INV 58
 #define HW_SVC_PARTICLE2 59
 #define HW_SVC_PARTICLE3 60
 #define HW_SVC_PARTICLE4 61
+#define HW_SVC_TURN_EFFECT 62
+#define HW_SVC_UPDATE_EFFECT 63
+#define HW_SVC_MULTIEFFECT 64
 #define HW_SVC_MIDI_NAME 65
 #define HW_SVC_RAINEFFECT 66
 #define HW_SVC_PACKMISSILE 67
+#define HW_SVC_INDEXED_PRINT 68
 #define HW_SVC_TARGETUPDATE 69
+#define HW_SVC_NAME_PRINT 70
 #define HW_SVC_SOUND_UPDATE_POS 71
 #define HW_SVC_UPDATE_PIV 72
 #define HW_SVC_PLAYER_SOUND 73
@@ -547,6 +610,235 @@ static void HWCL_ParseDamage (void)
 	HWCL_SkipCoords (3);
 }
 
+static void HWCL_SkipXbowBolts (int turned)
+{
+	int i;
+
+	for (i = 0; i < 5; i++)
+	{
+		if (turned & (1 << i))
+		{
+			HWCL_SkipCoords (3);
+			HWCL_SkipAngles (2);
+		}
+	}
+}
+
+static qboolean HWCL_ParseEffectPayload (int type)
+{
+	switch (type)
+	{
+	case CE_RAIN:
+		HWCL_SkipCoords (12);
+		MSG_ReadShort ();
+		MSG_ReadShort ();
+		MSG_ReadFloat ();
+		break;
+	case CE_FOUNTAIN:
+		HWCL_SkipCoords (3);
+		HWCL_SkipAngles (3);
+		HWCL_SkipCoords (3);
+		MSG_ReadShort ();
+		MSG_ReadByte ();
+		break;
+	case CE_QUAKE:
+		HWCL_SkipCoords (3);
+		MSG_ReadFloat ();
+		break;
+	case CE_WHITE_SMOKE:
+	case CE_GREEN_SMOKE:
+	case CE_GREY_SMOKE:
+	case CE_RED_SMOKE:
+	case CE_SLOW_WHITE_SMOKE:
+	case CE_TELESMK1:
+	case CE_TELESMK2:
+	case CE_GHOST:
+	case CE_REDCLOUD:
+	case CE_FLAMESTREAM:
+	case CE_ACID_MUZZFL:
+	case CE_FLAMEWALL:
+	case CE_FLAMEWALL2:
+	case CE_ONFIRE:
+	case CE_RIPPLE:
+		HWCL_SkipCoords (3);
+		HWCL_SkipFloats (4);
+		break;
+	case CE_SM_WHITE_FLASH:
+	case CE_YELLOWRED_FLASH:
+	case CE_BLUESPARK:
+	case CE_YELLOWSPARK:
+	case CE_SM_CIRCLE_EXP:
+	case CE_BG_CIRCLE_EXP:
+	case CE_SM_EXPLOSION:
+	case CE_SM_EXPLOSION2:
+	case CE_LG_EXPLOSION:
+	case CE_FLOOR_EXPLOSION:
+	case CE_BLUE_EXPLOSION:
+	case CE_REDSPARK:
+	case CE_GREENSPARK:
+	case CE_ICEHIT:
+	case CE_MEDUSA_HIT:
+	case CE_MEZZO_REFLECT:
+	case CE_FLOOR_EXPLOSION2:
+	case CE_XBOW_EXPLOSION:
+	case CE_NEW_EXPLOSION:
+	case CE_MAGIC_MISSILE_EXPLOSION:
+	case CE_BONE_EXPLOSION:
+	case CE_BLDRN_EXPL:
+	case CE_ACID_HIT:
+	case CE_ACID_SPLAT:
+	case CE_ACID_EXPL:
+	case CE_LBALL_EXPL:
+	case CE_FIREWALL_SMALL:
+	case CE_FIREWALL_MEDIUM:
+	case CE_FIREWALL_LARGE:
+	case CE_FBOOM:
+	case CE_BOMB:
+	case CE_BRN_BOUNCE:
+	case CE_LSHOCK:
+		HWCL_SkipCoords (3);
+		break;
+	case CE_WHITE_FLASH:
+	case CE_BLUE_FLASH:
+	case CE_SM_BLUE_FLASH:
+	case CE_HWSPLITFLASH:
+	case CE_RED_FLASH:
+	case CE_RIDER_DEATH:
+	case CE_TELEPORTERPUFFS:
+		HWCL_SkipCoords (3);
+		break;
+	case CE_TELEPORTERBODY:
+		HWCL_SkipCoords (3);
+		HWCL_SkipFloats (4);
+		break;
+	case CE_BONESHRAPNEL:
+	case CE_HWBONEBALL:
+		HWCL_SkipCoords (3);
+		HWCL_SkipFloats (9);
+		break;
+	case CE_BONESHARD:
+	case CE_HWRAVENSTAFF:
+	case CE_HWMISSILESTAR:
+	case CE_HWEIDOLONSTAR:
+	case CE_HWRAVENPOWER:
+		HWCL_SkipCoords (3);
+		HWCL_SkipFloats (3);
+		break;
+	case CE_HWDRILLA:
+		HWCL_SkipCoords (3);
+		HWCL_SkipAngles (2);
+		MSG_ReadShort ();
+		break;
+	case CE_DEATHBUBBLES:
+		MSG_ReadShort ();
+		MSG_ReadByte ();
+		MSG_ReadByte ();
+		MSG_ReadByte ();
+		MSG_ReadByte ();
+		break;
+	case CE_SCARABCHAIN:
+		HWCL_SkipCoords (3);
+		MSG_ReadShort ();
+		MSG_ReadByte ();
+		break;
+	case CE_TRIPMINESTILL:
+	case CE_TRIPMINE:
+		HWCL_SkipCoords (3);
+		HWCL_SkipFloats (3);
+		break;
+	case CE_HWSHEEPINATOR:
+		HWCL_SkipCoords (3);
+		HWCL_SkipAngles (2);
+		{
+			int turned = MSG_ReadByte ();
+			MSG_ReadByte ();
+			HWCL_SkipXbowBolts (turned);
+		}
+		break;
+	case CE_HWXBOWSHOOT:
+		HWCL_SkipCoords (3);
+		HWCL_SkipAngles (2);
+		MSG_ReadByte ();
+		MSG_ReadByte ();
+		{
+			int turned = MSG_ReadByte ();
+			MSG_ReadByte ();
+			HWCL_SkipXbowBolts (turned);
+		}
+		break;
+	default:
+		return false;
+	}
+	return !msg_badread;
+}
+
+static qboolean HWCL_ParseStartEffect (void)
+{
+	int idx = MSG_ReadByte ();
+	int type = MSG_ReadByte ();
+
+	(void)idx;
+	return HWCL_ParseEffectPayload (type);
+}
+
+static qboolean HWCL_ParseUpdateEffect (void)
+{
+	int idx = MSG_ReadByte ();
+	int type = MSG_ReadByte ();
+	int command;
+
+	(void)idx;
+	switch (type)
+	{
+	case CE_SCARABCHAIN:
+		MSG_ReadShort ();
+		break;
+	case CE_HWSHEEPINATOR:
+	case CE_HWXBOWSHOOT:
+		command = MSG_ReadByte ();
+		if (command & 1)
+			MSG_ReadCoord ();
+		else
+		{
+			MSG_ReadAngle ();
+			MSG_ReadAngle ();
+			if (command & 128)
+				HWCL_SkipCoords (3);
+		}
+		break;
+	case CE_HWDRILLA:
+		command = MSG_ReadByte ();
+		if (!command)
+		{
+			HWCL_SkipCoords (3);
+			MSG_ReadByte ();
+		}
+		else
+		{
+			MSG_ReadAngle ();
+			MSG_ReadAngle ();
+			HWCL_SkipCoords (3);
+		}
+		break;
+	default:
+		return false;
+	}
+	return !msg_badread;
+}
+
+static qboolean HWCL_ParseMultiEffect (void)
+{
+	int type = MSG_ReadByte ();
+	int i;
+
+	if (type != CE_HWRAVENPOWER)
+		return false;
+	HWCL_SkipCoords (6);
+	for (i = 0; i < 3; i++)
+		MSG_ReadByte ();
+	return !msg_badread;
+}
+
 static void HWCL_ParseInventoryUpdate (void)
 {
 	unsigned int sc1 = 0;
@@ -725,6 +1017,20 @@ static void HWCL_ParseServerMessage (void)
 		case HW_SVC_DAMAGE:
 			HWCL_ParseDamage ();
 			break;
+		case HW_SVC_SET_VIEW_TINT:
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_SET_VIEW_FLAGS:
+		case HW_SVC_CLEAR_VIEW_FLAGS:
+			MSG_ReadByte ();
+			break;
+		case HW_SVC_START_EFFECT:
+			if (!HWCL_ParseStartEffect ())
+				return;
+			break;
+		case HW_SVC_END_EFFECT:
+			MSG_ReadByte ();
+			break;
 		case HW_SVC_CENTERPRINT:
 			MSG_ReadString ();
 			break;
@@ -813,6 +1119,19 @@ static void HWCL_ParseServerMessage (void)
 		case HW_SVC_PARTICLE4:
 			HWCL_ParseParticle4 ();
 			break;
+		case HW_SVC_TURN_EFFECT:
+			MSG_ReadByte ();
+			MSG_ReadFloat ();
+			HWCL_SkipCoords (6);
+			break;
+		case HW_SVC_UPDATE_EFFECT:
+			if (!HWCL_ParseUpdateEffect ())
+				return;
+			break;
+		case HW_SVC_MULTIEFFECT:
+			if (!HWCL_ParseMultiEffect ())
+				return;
+			break;
 		case HW_SVC_RAINEFFECT:
 			HWCL_ParseRainEffect ();
 			break;
@@ -823,6 +1142,14 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadByte ();
 			MSG_ReadByte ();
 			MSG_ReadByte ();
+			break;
+		case HW_SVC_INDEXED_PRINT:
+			MSG_ReadByte (); /* print level */
+			MSG_ReadShort (); /* strings.txt index */
+			break;
+		case HW_SVC_NAME_PRINT:
+			MSG_ReadByte (); /* print level */
+			MSG_ReadByte (); /* player slot */
 			break;
 		case HW_SVC_SOUND_UPDATE_POS:
 			MSG_ReadShort ();

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -35,6 +35,7 @@
 #define HW_SVC_UPDATEFRAGS 14
 #define HW_SVC_STOPSOUND 16
 #define HW_SVC_PARTICLE 18
+#define HW_SVC_DAMAGE 19
 #define HW_SVC_SPAWNBASELINE 22
 #define HW_SVC_CENTERPRINT 26
 #define HW_SVC_KILLEDMONSTER 27
@@ -53,6 +54,7 @@
 #define HW_SVC_UPDATEUSERINFO 40
 #define HW_SVC_DOWNLOAD 41
 #define HW_SVC_PLAYERINFO 42
+#define HW_SVC_NAILS 43
 #define HW_SVC_CHOKECOUNT 44
 #define HW_SVC_MODELLIST 45
 #define HW_SVC_SOUNDLIST 46
@@ -468,6 +470,23 @@ static void HWCL_ParsePackedMissiles (void)
 		MSG_ReadByte ();
 }
 
+static void HWCL_ParseNails (void)
+{
+	int count;
+	int i;
+
+	count = MSG_ReadByte ();
+	for (i = 0; i < count * 6; i++)
+		MSG_ReadByte ();
+}
+
+static void HWCL_ParseDamage (void)
+{
+	MSG_ReadByte (); /* armor damage */
+	MSG_ReadByte (); /* blood damage */
+	HWCL_SkipCoords (3);
+}
+
 static void HWCL_ParseInventoryUpdate (void)
 {
 	unsigned int sc1 = 0;
@@ -642,6 +661,9 @@ static void HWCL_ParseServerMessage (void)
 		case HW_SVC_PARTICLE:
 			HWCL_ParseParticle ();
 			break;
+		case HW_SVC_DAMAGE:
+			HWCL_ParseDamage ();
+			break;
 		case HW_SVC_CENTERPRINT:
 			MSG_ReadString ();
 			break;
@@ -699,6 +721,9 @@ static void HWCL_ParseServerMessage (void)
 			break;
 		case HW_SVC_PLAYERINFO:
 			HWCL_ParsePlayerInfo ();
+			break;
+		case HW_SVC_NAILS:
+			HWCL_ParseNails ();
 			break;
 		case HW_SVC_PACKETENTITIES:
 			HWCL_ParsePacketEntities (false);

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -592,16 +592,43 @@ static void HWCL_SkipUsercmd (void)
 static void HWCL_ParseSound (void)
 {
 	int channel;
+	int sound_num;
+	int volume = 255;
+	float attenuation = 1.0f;
+	vec3_t origin;
 	int i;
 
 	channel = MSG_ReadShort ();
 	if (channel & HW_SND_VOLUME)
-		MSG_ReadByte ();
+		volume = MSG_ReadByte ();
 	if (channel & HW_SND_ATTENUATION)
-		MSG_ReadByte ();
-	MSG_ReadByte (); /* sound index */
+		attenuation = MSG_ReadByte () / 32.0f;
+	sound_num = MSG_ReadByte ();
 	for (i = 0; i < 3; i++)
-		MSG_ReadCoord ();
+		origin[i] = MSG_ReadCoord ();
+	if (!msg_badread && sound_num > 0 && sound_num < MAX_SOUNDS &&
+			cl.sound_precache[sound_num])
+		S_StartSound (channel >> 3, channel & 7, cl.sound_precache[sound_num],
+				origin, volume / 255.0f, attenuation);
+}
+
+static void HWCL_ParseStaticSound (void)
+{
+	vec3_t origin;
+	int sound_num;
+	int volume;
+	int attenuation;
+
+	origin[0] = MSG_ReadCoord ();
+	origin[1] = MSG_ReadCoord ();
+	origin[2] = MSG_ReadCoord ();
+	sound_num = MSG_ReadByte ();
+	volume = MSG_ReadByte ();
+	attenuation = MSG_ReadByte ();
+	if (!msg_badread && sound_num > 0 && sound_num < MAX_SOUNDS &&
+			cl.sound_precache[sound_num])
+		S_StaticSound (cl.sound_precache[sound_num], origin, volume / 255.0f,
+				attenuation / 32.0f);
 }
 
 static void HWCL_ParseDownload (void)
@@ -623,6 +650,14 @@ static void HWCL_SkipCoords (int count)
 
 	for (i = 0; i < count; i++)
 		MSG_ReadCoord ();
+}
+
+static void HWCL_ReadCoords (vec3_t coords)
+{
+	int i;
+
+	for (i = 0; i < 3; i++)
+		coords[i] = MSG_ReadCoord ();
 }
 
 static void HWCL_SkipAngles (int count)
@@ -739,9 +774,7 @@ static const char *HWCL_InfoValue (const char *info, const char *key)
 
 static void HWCL_ParseDamage (void)
 {
-	MSG_ReadByte (); /* armor damage */
-	MSG_ReadByte (); /* blood damage */
-	HWCL_SkipCoords (3);
+	V_ParseDamage ();
 }
 
 static void HWCL_SkipXbowBolts (int turned)
@@ -1248,10 +1281,21 @@ static void HWCL_ParseServerMessage (void)
 			hwcl_server_state.viewangles[1] = MSG_ReadAngle ();
 			hwcl_server_state.viewangles[2] = MSG_ReadAngle ();
 			VectorCopy (hwcl_server_state.viewangles, cl.viewangles);
+			CL_LatchFixAngle ();
 			break;
 		case HW_SVC_LIGHTSTYLE:
-			MSG_ReadByte ();
-			MSG_ReadString ();
+			{
+				int style = MSG_ReadByte ();
+				const char *map = MSG_ReadString ();
+				if (style >= 0 && style < MAX_LIGHTSTYLES)
+				{
+					q_strlcpy (cl_lightstyle[style].map, map,
+							sizeof(cl_lightstyle[style].map));
+					cl_lightstyle[style].length = strlen (
+						cl_lightstyle[style].map);
+					CL_SetLightstyleLevels (&cl_lightstyle[style]);
+				}
+			}
 			break;
 		case HW_SVC_SOUND:
 			HWCL_ParseSound ();
@@ -1265,7 +1309,10 @@ static void HWCL_ParseServerMessage (void)
 			}
 			break;
 		case HW_SVC_STOPSOUND:
-			MSG_ReadShort ();
+			{
+				int channel = MSG_ReadShort ();
+				S_StopSound (channel >> 3, channel & 7);
+			}
 			break;
 		case HW_SVC_PARTICLE:
 			HWCL_ParseParticle ();
@@ -1274,11 +1321,13 @@ static void HWCL_ParseServerMessage (void)
 			HWCL_ParseDamage ();
 			break;
 		case HW_SVC_SET_VIEW_TINT:
-			MSG_ReadByte ();
+			cl.viewent.colorshade = MSG_ReadByte ();
 			break;
 		case HW_SVC_SET_VIEW_FLAGS:
+			cl.viewent.drawflags |= MSG_ReadByte ();
+			break;
 		case HW_SVC_CLEAR_VIEW_FLAGS:
-			MSG_ReadByte ();
+			cl.viewent.drawflags &= ~MSG_ReadByte ();
 			break;
 		case HW_SVC_START_EFFECT:
 			if (!HWCL_ParseStartEffect ())
@@ -1288,7 +1337,7 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadByte ();
 			break;
 		case HW_SVC_CENTERPRINT:
-			MSG_ReadString ();
+			SCR_CenterPrint (MSG_ReadString ());
 			break;
 		case HW_SVC_KILLEDMONSTER:
 		case HW_SVC_FOUNDSECRET:
@@ -1297,17 +1346,14 @@ static void HWCL_ParseServerMessage (void)
 		case HW_SVC_BIGKICK:
 			break;
 		case HW_SVC_SPAWNSTATICSOUND:
-			HWCL_SkipCoords (3);
-			MSG_ReadByte ();
-			MSG_ReadByte ();
-			MSG_ReadByte ();
+			HWCL_ParseStaticSound ();
 			break;
 		case HW_SVC_INTERMISSION:
 			HWCL_SkipCoords (3);
 			HWCL_SkipAngles (3);
 			break;
 		case HW_SVC_FINALE:
-			MSG_ReadString ();
+			SCR_CenterPrint (MSG_ReadString ());
 			break;
 		case HW_SVC_CDTRACK:
 			hwcl_server_state.cdtrack = MSG_ReadByte ();
@@ -1426,16 +1472,30 @@ static void HWCL_ParseServerMessage (void)
 			MSG_ReadByte (); /* player slot */
 			break;
 		case HW_SVC_SOUND_UPDATE_POS:
-			MSG_ReadShort ();
-			HWCL_SkipCoords (3);
+			{
+				vec3_t origin;
+				int channel = MSG_ReadShort ();
+				HWCL_ReadCoords (origin);
+				if (!msg_badread)
+					S_UpdateSoundPos (channel >> 3, channel & 7, origin);
+			}
 			break;
 		case HW_SVC_UPDATE_PIV:
 			hwcl_server_state.piv = MSG_ReadLong ();
 			break;
 		case HW_SVC_PLAYER_SOUND:
-			MSG_ReadByte ();
-			HWCL_SkipCoords (3);
-			MSG_ReadShort ();
+			{
+				vec3_t origin;
+				int slot = MSG_ReadByte ();
+				int sound_num;
+				HWCL_ReadCoords (origin);
+				sound_num = MSG_ReadShort ();
+				if (!msg_badread && slot >= 0 && slot < cl.maxclients &&
+						sound_num > 0 && sound_num < MAX_SOUNDS &&
+						cl.sound_precache[sound_num])
+					S_StartSound (slot + 1, 2, cl.sound_precache[sound_num],
+							origin, 1.0f, 1.0f);
+			}
 			break;
 		case HW_SVC_UPDATEPCLASS:
 			{

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -59,6 +59,7 @@
 #define HW_SVC_DELTAPACKETENTITIES 48
 #define HW_SVC_MAXSPEED 49
 #define HW_SVC_ENTGRAVITY 50
+#define HW_SVC_UPDATE_INV 58
 #define HW_SVC_MIDI_NAME 65
 #define HW_SVC_TARGETUPDATE 69
 #define HW_SVC_SOUND_UPDATE_POS 71
@@ -396,6 +397,79 @@ static void HWCL_SkipAngles (int count)
 		MSG_ReadAngle ();
 }
 
+static void HWCL_ParseInventoryUpdate (void)
+{
+	unsigned int sc1 = 0;
+	unsigned int sc2 = 0;
+	int groups;
+
+	groups = MSG_ReadByte ();
+	if (groups & 1) sc1 |= (unsigned int)MSG_ReadByte ();
+	if (groups & 2) sc1 |= (unsigned int)MSG_ReadByte () << 8;
+	if (groups & 4) sc1 |= (unsigned int)MSG_ReadByte () << 16;
+	if (groups & 8) sc1 |= (unsigned int)MSG_ReadByte () << 24;
+	if (groups & 16) sc2 |= (unsigned int)MSG_ReadByte ();
+	if (groups & 32) sc2 |= (unsigned int)MSG_ReadByte () << 8;
+	if (groups & 64) sc2 |= (unsigned int)MSG_ReadByte () << 16;
+	if (groups & 128) sc2 |= (unsigned int)MSG_ReadByte () << 24;
+
+	if (sc1 & (1u << 0)) MSG_ReadShort (); /* health */
+	if (sc1 & (1u << 1)) MSG_ReadByte (); /* level */
+	if (sc1 & (1u << 2)) MSG_ReadByte (); /* intelligence */
+	if (sc1 & (1u << 3)) MSG_ReadByte (); /* wisdom */
+	if (sc1 & (1u << 4)) MSG_ReadByte (); /* strength */
+	if (sc1 & (1u << 5)) MSG_ReadByte (); /* dexterity */
+	/* Bit 6 is SC1_TELEPORT_TIME in the protocol header, but this server's
+	 * writer does not serialize a payload for it. */
+	if (sc1 & (1u << 7)) MSG_ReadByte (); /* bluemana */
+	if (sc1 & (1u << 8)) MSG_ReadByte (); /* greenmana */
+	if (sc1 & (1u << 9)) MSG_ReadLong (); /* experience */
+	if (sc1 & (1u << 10)) MSG_ReadByte (); /* cnt_torch */
+	if (sc1 & (1u << 11)) MSG_ReadByte (); /* cnt_h_boost */
+	if (sc1 & (1u << 12)) MSG_ReadByte (); /* cnt_sh_boost */
+	if (sc1 & (1u << 13)) MSG_ReadByte (); /* cnt_mana_boost */
+	if (sc1 & (1u << 14)) MSG_ReadByte (); /* cnt_teleport */
+	if (sc1 & (1u << 15)) MSG_ReadByte (); /* cnt_tome */
+	if (sc1 & (1u << 16)) MSG_ReadByte (); /* cnt_summon */
+	if (sc1 & (1u << 17)) MSG_ReadByte (); /* cnt_invisibility */
+	if (sc1 & (1u << 18)) MSG_ReadByte (); /* cnt_glyph */
+	if (sc1 & (1u << 19)) MSG_ReadByte (); /* cnt_haste */
+	if (sc1 & (1u << 20)) MSG_ReadByte (); /* cnt_blast */
+	if (sc1 & (1u << 21)) MSG_ReadByte (); /* cnt_polymorph */
+	if (sc1 & (1u << 22)) MSG_ReadByte (); /* cnt_flight */
+	if (sc1 & (1u << 23)) MSG_ReadByte (); /* cnt_cubeofforce */
+	if (sc1 & (1u << 24)) MSG_ReadByte (); /* cnt_invincibility */
+	if (sc1 & (1u << 25)) MSG_ReadByte (); /* artifact_active */
+	if (sc1 & (1u << 26)) MSG_ReadByte (); /* artifact_low */
+	if (sc1 & (1u << 27)) MSG_ReadByte (); /* movetype */
+	if (sc1 & (1u << 28)) MSG_ReadByte (); /* cameramode */
+	if (sc1 & (1u << 29)) MSG_ReadFloat (); /* hasted */
+	if (sc1 & (1u << 30)) MSG_ReadByte (); /* inventory */
+	if (sc1 & (1u << 31)) MSG_ReadByte (); /* rings_active */
+
+	if (sc2 & (1u << 0)) MSG_ReadByte (); /* rings_low */
+	if (sc2 & (1u << 1)) MSG_ReadByte (); /* armor_amulet */
+	if (sc2 & (1u << 2)) MSG_ReadByte (); /* armor_bracer */
+	if (sc2 & (1u << 3)) MSG_ReadByte (); /* armor_breastplate */
+	if (sc2 & (1u << 4)) MSG_ReadByte (); /* armor_helmet */
+	if (sc2 & (1u << 5)) MSG_ReadByte (); /* ring_flight */
+	if (sc2 & (1u << 6)) MSG_ReadByte (); /* ring_water */
+	if (sc2 & (1u << 7)) MSG_ReadByte (); /* ring_turning */
+	if (sc2 & (1u << 8)) MSG_ReadByte (); /* ring_regeneration */
+	/* Bits 9 and 10 are declared but not serialized by this server. */
+	if (sc2 & (1u << 11)) MSG_ReadString (); /* puzzle_inv1 */
+	if (sc2 & (1u << 12)) MSG_ReadString (); /* puzzle_inv2 */
+	if (sc2 & (1u << 13)) MSG_ReadString (); /* puzzle_inv3 */
+	if (sc2 & (1u << 14)) MSG_ReadString (); /* puzzle_inv4 */
+	if (sc2 & (1u << 15)) MSG_ReadString (); /* puzzle_inv5 */
+	if (sc2 & (1u << 16)) MSG_ReadString (); /* puzzle_inv6 */
+	if (sc2 & (1u << 17)) MSG_ReadString (); /* puzzle_inv7 */
+	if (sc2 & (1u << 18)) MSG_ReadString (); /* puzzle_inv8 */
+	if (sc2 & (1u << 19)) MSG_ReadShort (); /* max_health */
+	if (sc2 & (1u << 20)) MSG_ReadByte (); /* max_mana */
+	if (sc2 & (1u << 21)) MSG_ReadFloat (); /* flags */
+}
+
 static void HWCL_ParsePlayerInfo (void)
 {
 	hwcl_entity_state_t discard = {0};
@@ -566,6 +640,9 @@ static void HWCL_ParseServerMessage (void)
 			break;
 		case HW_SVC_ENTGRAVITY:
 			hwcl_server_state.entgravity = MSG_ReadFloat ();
+			break;
+		case HW_SVC_UPDATE_INV:
+			HWCL_ParseInventoryUpdate ();
 			break;
 		case HW_SVC_TARGETUPDATE:
 			MSG_ReadByte ();

--- a/engine/hexen2/cl_hw.h
+++ b/engine/hexen2/cl_hw.h
@@ -5,6 +5,7 @@
 #if defined(H2W_INTEGRATED)
 qboolean HWCL_Connect (const char *host);
 void HWCL_SendCmd (const usercmd_t *cmd);
+void HWCL_ApplyState (void);
 qboolean HWCL_Active (void);
 void HWCL_Disconnect (void);
 void HWCL_Frame (void);

--- a/engine/hexen2/cl_hw.h
+++ b/engine/hexen2/cl_hw.h
@@ -4,6 +4,7 @@
 
 #if defined(H2W_INTEGRATED)
 qboolean HWCL_Connect (const char *host);
+void HWCL_SendCmd (const usercmd_t *cmd);
 qboolean HWCL_Active (void);
 void HWCL_Disconnect (void);
 void HWCL_Frame (void);

--- a/engine/hexen2/cl_hw.h
+++ b/engine/hexen2/cl_hw.h
@@ -1,0 +1,13 @@
+/* HexenWorld client networking integrated into Hexenwail. */
+#ifndef HX2_CL_HW_H
+#define HX2_CL_HW_H
+
+#if defined(H2W_INTEGRATED)
+qboolean HWCL_Connect (const char *host);
+qboolean HWCL_Active (void);
+void HWCL_Disconnect (void);
+void HWCL_Frame (void);
+void HWCL_Shutdown (void);
+#endif
+
+#endif /* HX2_CL_HW_H */

--- a/engine/hexen2/cl_input.c
+++ b/engine/hexen2/cl_input.c
@@ -636,6 +636,29 @@ void CL_BaseMove (usercmd_t *cmd)
 }
 
 
+int CL_GetButtonBits (void)
+{
+	int bits = 0;
+
+	if (in_attack.state & 3)
+		bits |= 1;
+	in_attack.state &= ~2;
+	if (in_jump.state & 3)
+		bits |= 2;
+	in_jump.state &= ~2;
+	if (in_crouch.state & 1)
+		bits |= 4;
+	return bits;
+}
+
+int CL_GetImpulse (void)
+{
+	int impulse = in_impulse;
+
+	in_impulse = 0;
+	return impulse;
+}
+
 /*
 ==============
 CL_SendMove
@@ -668,23 +691,9 @@ void CL_SendMove (const usercmd_t *cmd)
 	MSG_WriteShort (&buf, cmd->upmove);
 
 // send button bits
-	bits = 0;
-
-	if (in_attack.state & 3)
-		bits |= 1;
-	in_attack.state &= ~2;
-
-	if (in_jump.state & 3)
-		bits |= 2;
-	in_jump.state &= ~2;
-
-	if (in_crouch.state & 1)
-		bits |= 4;
-
+	bits = CL_GetButtonBits ();
 	MSG_WriteByte (&buf, bits);
-
-	MSG_WriteByte (&buf, in_impulse);
-	in_impulse = 0;
+	MSG_WriteByte (&buf, CL_GetImpulse ());
 
 // light level
 	MSG_WriteByte (&buf, cmd->lightlevel);

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -1417,6 +1417,25 @@ void CL_SendCmd (void)
 {
 	usercmd_t	cmd;
 
+#if defined(H2W_INTEGRATED)
+	if (HWCL_Active ())
+	{
+		if (cls.signon != SIGNONS)
+			return;
+
+		CL_BaseMove (&cmd);
+		cmd.forwardmove += cl.pendingcmd.forwardmove;
+		cmd.sidemove += cl.pendingcmd.sidemove;
+		cmd.upmove += cl.pendingcmd.upmove;
+		memset (&cl.pendingcmd, 0, sizeof(cl.pendingcmd));
+		cmd.forwardmove += cl.analogmove.forwardmove;
+		cmd.sidemove += cl.analogmove.sidemove;
+		cmd.upmove += cl.analogmove.upmove;
+		HWCL_SendCmd (&cmd);
+		return;
+	}
+#endif
+
 	if (cls.state != ca_connected)
 		return;
 

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -1326,10 +1326,17 @@ int CL_ReadFromServer (void)
 	if (HWCL_Active ())
 	{
 		/* HexenWorld owns its socket and netchan; do not ask the Hexen II
-		 * qsocket layer to read a null cls.netcon. */
-		CL_AdvanceTime ();
+		 * qsocket layer to read a null cls.netcon.  Its retained snapshots
+		 * feed the maintained renderer through the same relink path as H2. */
+		HWCL_ApplyState ();
+		CL_RelinkEntities ();
+		CL_UpdateEffects ();
+		CL_UpdateTEnts ();
+		CL_UpdateDevStats ();
 		return 0;
 	}
+	if (!cls.netcon)
+		return 0;
 #endif
 
 	/* Demo playback runs this clock at cls.demospeed, which is what pause,

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -1328,6 +1328,7 @@ int CL_ReadFromServer (void)
 		/* HexenWorld owns its socket and netchan; do not ask the Hexen II
 		 * qsocket layer to read a null cls.netcon.  Its retained snapshots
 		 * feed the maintained renderer through the same relink path as H2. */
+		CL_AdvanceTime ();
 		HWCL_ApplyState ();
 		CL_RelinkEntities ();
 		CL_UpdateEffects ();

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -24,6 +24,7 @@
 #include "bgmusic.h"
 #include "cdaudio.h"
 #include "cl_csqc.h"
+#include "cl_hw.h"
 
 // we need to declare some mouse variables here, because the menu system
 // references them even when on a unix system.
@@ -169,6 +170,9 @@ This is also called on Host_Error, so it shouldn't cause any errors
 */
 void CL_Disconnect (void)
 {
+#if defined(H2W_INTEGRATED)
+	HWCL_Disconnect ();
+#endif
 // don't get stuck in chat mode
 	if (Key_GetDest() == key_message)
 		Key_EndChat ();
@@ -240,6 +244,16 @@ void CL_EstablishConnection (const char *host)
 		return;
 
 	CL_Disconnect ();
+
+#if defined(H2W_INTEGRATED)
+	/* The URI makes protocol selection explicit; ordinary host names retain
+	 * Hexen II's qsocket handshake. */
+	if (!q_strncasecmp(host, "hw://", 5))
+	{
+		HWCL_Connect (host + 5);
+		return;
+	}
+#endif
 
 	cls.netcon = NET_Connect (host);
 	if (!cls.netcon)
@@ -1306,6 +1320,17 @@ Read all incoming data from the server
 int CL_ReadFromServer (void)
 {
 	int	ret;
+
+#if defined(H2W_INTEGRATED)
+	HWCL_Frame ();
+	if (HWCL_Active ())
+	{
+		/* HexenWorld owns its socket and netchan; do not ask the Hexen II
+		 * qsocket layer to read a null cls.netcon. */
+		CL_AdvanceTime ();
+		return 0;
+	}
+#endif
 
 	/* Demo playback runs this clock at cls.demospeed, which is what pause,
 	 * slow motion and fast-forward actually are.  uhexen2-ofl9. */

--- a/engine/hexen2/client.h
+++ b/engine/hexen2/client.h
@@ -503,6 +503,8 @@ void CL_InitInput (void);
 void CL_SendCmd (void);
 void CL_AdjustAngles (void);
 void CL_BaseMove (usercmd_t *cmd);
+int CL_GetButtonBits (void);
+int CL_GetImpulse (void);
 void CL_SendMove (const usercmd_t *cmd);
 
 //

--- a/engine/hexen2/host.c
+++ b/engine/hexen2/host.c
@@ -26,6 +26,7 @@
 #include "cfgfile.h"
 #include "debuglog.h"
 #include "bgmusic.h"
+#include "cl_hw.h"
 
 extern int VID_MenuGetVSync (void);
 #include "cdaudio.h"
@@ -1429,7 +1430,11 @@ static void _Host_Frame (float time)
 	R_UpdateParticles ();
 
 // read from server and interpolate entities every render frame
-	if (cls.state == ca_connected)
+	if (cls.state == ca_connected
+#if defined(H2W_INTEGRATED)
+	    || HWCL_Active ()
+#endif
+	   )
 		CL_ReadFromServer ();
 
 // update video
@@ -1672,6 +1677,9 @@ void Host_Shutdown(void)
 
 	Host_WriteConfiguration ("config.cfg");
 
+#if defined(H2W_INTEGRATED)
+	HWCL_Shutdown ();
+#endif
 	NET_Shutdown ();
 
 	if (cls.state != ca_dedicated)

--- a/engine/hexenworld/README.md
+++ b/engine/hexenworld/README.md
@@ -64,8 +64,13 @@ above), and the older 0.11 and 0.09 betas.  Prefer 0.15.
 
 ### 3. HexenWorld gamecode — `hw/hwprogs.dat`
 
-Built from source in this tree, so no acquisition problem — but nothing installs
-it into a game directory for you:
+Built from source in this tree, so no acquisition problem. Install via the bundled package:
+
+    nix build .#hwsv-bundled
+
+This creates a complete installation with both the `hwsv` binary and `hw/hwprogs.dat` in the correct location.
+
+Alternatively, you can install the gamecode manually from the gamecode package:
 
     nix build .#gamecode
     install -Dm644 result/share/hexenwail/hw/hwprogs.dat <gamedir>/hw/hwprogs.dat

--- a/engine/hexenworld/README.md
+++ b/engine/hexenworld/README.md
@@ -30,10 +30,10 @@ explicitly with:
     connect hw://server.example:26950
 
 The integrated path completes connectionless acceptance, establishes the
-sequenced netchan, validates protocol 24/25/26/100 server data, and advances
-the sound/model-list and baseline signon exchange.  Gameplay state, assets,
-and presentation messages still need to be routed into the shared Hexenwail
-client.
+sequenced netchan, validates protocol 24/25/26/100 server data, and completes
+the sound/model-list, baseline, spawn, and begin transport handshake.
+Gameplay state, assets, and presentation messages still need to be routed into
+the shared Hexenwail client.
 
 The flag is required at *configure* time — it gates whether `add_executable(hwsv)`
 is reached at all, so `make hwsv` without it asks for a target the generated

--- a/engine/hexenworld/README.md
+++ b/engine/hexenworld/README.md
@@ -29,9 +29,11 @@ explicitly with:
 
     connect hw://server.example:26950
 
-The integrated path currently completes the connectionless acceptance and
-establishes the sequenced netchan.  Server-message parsing and gameplay state
-still need to be routed into the shared Hexenwail client.
+The integrated path completes connectionless acceptance, establishes the
+sequenced netchan, validates protocol 24/25/26/100 server data, and advances
+the sound/model-list and baseline signon exchange.  Gameplay state, assets,
+and presentation messages still need to be routed into the shared Hexenwail
+client.
 
 The flag is required at *configure* time — it gates whether `add_executable(hwsv)`
 is reached at all, so `make hwsv` without it asks for a target the generated

--- a/engine/hexenworld/README.md
+++ b/engine/hexenworld/README.md
@@ -5,9 +5,11 @@ engine* that shares `h2shared` with Hexen II — its own protocol, its own
 gamecode (`hwprogs.dat`), its own client prediction and master server — not a
 mode of the Hexen II server.
 
-`engine/hexenworld/` holds only the dedicated server (`hwsv`); the HexenWorld
-client (`hwcl` / `glhwcl`) is not restored.  The master server and its helper
-tools *are* built, but from `hw_utils/` rather than here — `hwmaster`,
+`engine/hexenworld/` holds the dedicated server (`hwsv`) and the shared
+HexenWorld protocol/transport.  There is deliberately no restored `hwcl` or
+`glhwcl` executable: HexenWorld client networking is being integrated as a
+protocol mode of Hexenwail itself.  The master server and its helper tools
+*are* built, but from `hw_utils/` rather than here — `hwmaster`,
 `hwmquery`, `hwrcon` and `hwterm` all come out of `nix build .#utils`, which
 CI already runs.
 
@@ -20,6 +22,16 @@ CI already runs.
 or via the flake:
 
     nix build .#hwsv
+
+Hexenwail includes the namespaced HexenWorld UDP, Huffman and netchan transport
+by default (`-DUSE_HEXENWORLD_CLIENT=OFF` disables it). Start that protocol path
+explicitly with:
+
+    connect hw://server.example:26950
+
+The integrated path currently completes the connectionless acceptance and
+establishes the sequenced netchan.  Server-message parsing and gameplay state
+still need to be routed into the shared Hexenwail client.
 
 The flag is required at *configure* time — it gates whether `add_executable(hwsv)`
 is reached at all, so `make hwsv` without it asks for a target the generated
@@ -110,8 +122,9 @@ See GitHub issue #35.
 - Two `hwsv` instances discovering each other via `hwmaster`.  Not blocked on
   building anything — `hwmaster` already ships in `.#utils`.  What is missing is
   a harness that starts a master plus two servers and asserts the heartbeat.
-- A real HexenWorld client completing the connectionless handshake — `hwcl` is
-  not built in this tree; needs an upstream or community client.
+- Complete parsing of HexenWorld server messages in the integrated Hexenwail
+  client.  The connectionless handshake and sequenced netchan are in-tree; the
+  old standalone `hwcl` executable will not be restored.
 - Whether this engine's modern wire extensions ride over the HexenWorld protocol
   at all, or are Hexen II only.  Undecided; `hwsv` must not silently drop
   clients that advertise them.

--- a/engine/hexenworld/shared/huffman.c
+++ b/engine/hexenworld/shared/huffman.c
@@ -22,8 +22,21 @@
 #include "huffman.h"
 /* h2w engine includes */
 #undef	USE_INTEL_ASM
-/* use Hunk_Alloc or malloc : */
+/* use Hunk_Alloc or malloc :
+ *
+ * hwsv builds this tree once at startup and never clears the hunk under it,
+ * so the hunk is free.  The integrated Hexenwail client cannot use it: it
+ * calls HuffInit from HWCL_InitNet, and CL_ClearState -> Host_ClearMemory
+ * then does Hunk_FreeToLowMark and takes the tree with it, leaving HuffTree
+ * dangling.  Connectionless packets take HuffDecode's raw 0xff path and never
+ * notice; the first sequenced packet walks the freed tree and segfaults --
+ * or does not, depending on whether anything has reused the memory yet.
+ * A one-shot malloc for the life of the process is what this actually wants. */
+#ifdef H2W_INTEGRATED
+#define USE_HUNKMEM	0
+#else
 #define USE_HUNKMEM	1
+#endif
 #include "arch_def.h"
 #include "sys.h"
 #include "printsys.h"

--- a/engine/hexenworld/shared/net.h
+++ b/engine/hexenworld/shared/net.h
@@ -21,7 +21,39 @@
 #ifndef __H2W_NET_H
 #define __H2W_NET_H
 
-#define	PORT_ANY	-1
+/* HexenWorld's QuakeWorld-derived transport now also links into the main
+ * Hexenwail client.  Keep every external symbol in its own namespace there
+ * so it can coexist with Hexen II's qsocket networking in one executable.
+ * hwsv retains the historical symbols because h2shared's message reader
+ * refers to net_message directly. */
+#ifdef H2W_INTEGRATED
+#define net_local_adr			hw_net_local_adr
+#define net_loopback_adr		hw_net_loopback_adr
+#define net_from			hw_net_from
+#define net_message			hw_net_message
+#define net_drop			hw_net_drop
+#define NET_Init			HWNET_Init
+#define NET_Shutdown			HWNET_Shutdown
+#define NET_GetPacket			HWNET_GetPacket
+#define NET_SendPacket			HWNET_SendPacket
+#define NET_CheckReadTimeout		HWNET_CheckReadTimeout
+#define NET_CompareAdr			HWNET_CompareAdr
+#define NET_CompareBaseAdr		HWNET_CompareBaseAdr
+#define NET_AdrToString			HWNET_AdrToString
+#define NET_BaseAdrToString		HWNET_BaseAdrToString
+#define NET_StringToAdr			HWNET_StringToAdr
+#define Netchan_Init			HWNetchan_Init
+#define Netchan_Transmit		HWNetchan_Transmit
+#define Netchan_OutOfBand		HWNetchan_OutOfBand
+#define Netchan_OutOfBandPrint		HWNetchan_OutOfBandPrint
+#define Netchan_Process			HWNetchan_Process
+#define Netchan_Setup			HWNetchan_Setup
+#define Netchan_CanPacket		HWNetchan_CanPacket
+#define Netchan_CanReliable		HWNetchan_CanReliable
+#endif
+
+#define	PORT_ANY		-1
+#define	HWNET_MAX_MSGLEN	7500
 
 typedef struct
 {
@@ -89,10 +121,10 @@ typedef struct
 
 	// reliable staging and holding areas
 	sizebuf_t	message;		// writing buffer to send to server
-	byte		message_buf[MAX_MSGLEN];
+	byte		message_buf[HWNET_MAX_MSGLEN];
 
 	int	reliable_length;
-	byte	reliable_buf[MAX_MSGLEN];	// unacked reliable message
+	byte	reliable_buf[HWNET_MAX_MSGLEN];	// unacked reliable message
 
 	// time and size data to calculate bandwidth
 	int	outgoing_size[MAX_LATENT];

--- a/engine/hexenworld/shared/net_chan.c
+++ b/engine/hexenworld/shared/net_chan.c
@@ -20,7 +20,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef H2W_INTEGRATED
+#include "../../hexen2/quakedef.h"
+#include "net.h"
+#else
 #include "quakedef.h"
+#endif
 
 #define	PACKET_HEADER	8
 
@@ -96,7 +101,7 @@ Sends an out-of-band datagram
 void Netchan_OutOfBand (const netadr_t *adr, int length, byte *data)
 {
 	sizebuf_t	senddata;
-	byte		send_buf[MAX_MSGLEN + PACKET_HEADER];
+	byte		send_buf[HWNET_MAX_MSGLEN + PACKET_HEADER];
 
 // write the packet header
 	SZ_Init (&senddata, send_buf, sizeof(send_buf));
@@ -194,7 +199,7 @@ A 0 length will still generate a packet and deal with the reliable messages.
 void Netchan_Transmit (netchan_t *chan, int length, byte *data)
 {
 	sizebuf_t	senddata;
-	byte		send_buf[MAX_MSGLEN + PACKET_HEADER];
+	byte		send_buf[HWNET_MAX_MSGLEN + PACKET_HEADER];
 	qboolean	send_reliable;
 	unsigned int	w1, w2;
 	int		i;
@@ -290,7 +295,11 @@ qboolean Netchan_Process (netchan_t *chan)
 	}
 
 // get sequence numbers
+#ifdef H2W_INTEGRATED
+	MSG_BeginReadingFrom (&net_message);
+#else
 	MSG_BeginReading ();
+#endif
 	sequence = MSG_ReadLong ();
 	sequence_ack = MSG_ReadLong ();
 

--- a/engine/hexenworld/shared/net_udp.c
+++ b/engine/hexenworld/shared/net_udp.c
@@ -23,7 +23,12 @@
 #include "q_stdinc.h"
 #include "arch_def.h"
 #include "net_sys.h"
+#ifdef H2W_INTEGRATED
+#include "../../hexen2/quakedef.h"
+#include "net.h"
+#else
 #include "quakedef.h"
+#endif
 #include "huffman.h"
 
 //=============================================================================
@@ -45,7 +50,7 @@ struct Library	*SocketBase;
 static WSADATA	winsockdata;
 #endif
 
-#define	MAX_UDP_PACKET	(MAX_MSGLEN + 9)	/* one more than msg + header */
+#define	MAX_UDP_PACKET	(HWNET_MAX_MSGLEN + 9)	/* one more than msg + header */
 static byte	net_message_buffer[MAX_UDP_PACKET];
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -341,6 +341,31 @@
                 -t $out/share/hexenwail/portals
             '';
 
+          # HexenWorld dedicated server with bundled gamecode.  hwsv needs
+          # hw/hwprogs.dat to start -- see FS_Init's GAME_HEXENWORLD gate.
+          # A bare .#hwsv has the same gap as .#h2ded vs Raven's progs.dat,
+          # and hwprogs.dat has no retail equivalent a user could supply
+          # instead -- it only ever came from Raven's free release, compiled
+          # from source in this tree.  uhexen2-9die.
+          hwsv-bundled =
+            let
+              hwsvPkg = self.packages.${system}.hwsv;
+              gamecodePkg = self.packages.${system}.gamecode;
+            in pkgs.runCommand "hexenwail-hwsv-bundled-${hwsvPkg.version}" {
+              meta = hwsvPkg.meta // {
+                description = "${hwsvPkg.meta.description} (with bundled gamecode)";
+              };
+              passthru = { inherit (hwsvPkg) version; };
+            } ''
+              mkdir -p $out/bin
+              cp ${hwsvPkg}/bin/hwsv $out/bin/hwsv
+              chmod +w $out/bin/hwsv
+
+              install -Dm644 \
+                ${gamecodePkg}/share/hexenwail/hw/hwprogs.dat \
+                -t $out/share/hexenwail/hw
+            '';
+
           default = self.packages.${system}.nixos-bundled;
 
           # Dedicated server (h2ded) — headless, links only libm/libc.


### PR DESCRIPTION
## Summary

This starts the HexenWorld client bring-up as a protocol mode inside Hexenwail. It deliberately does **not** restore a separate `hwcl`/`glhwcl` executable.

Current branch:

- packages `hwsv` together with `hw/hwprogs.dat`
- compiles the HexenWorld UDP, Huffman, and netchan transport into `glhexen2`
- namespaces the transport so it coexists with Hexen II's qsocket stack
- selects HexenWorld explicitly with `connect hw://host:port`
- completes connectionless acceptance and establishes a sequenced netchan
- allows message readers to select either protocol's packet buffer

## Runtime validation

Validated against the public master at `52.240.58.168:27900` and all three servers it advertised:

- `168.138.68.8:26955` — connection accepted, netchan established
- `168.138.68.8:26956` — connection accepted, netchan established
- `168.138.68.8:26950` — connection accepted, netchan established

Also validated against a local `hwsv +map demo1` using retail Hexen II data, `hw/pak4.pak`, and bundled `hwprogs.dat`.

Build validation:

```text
nix build .#nixos
nix build .#hwsv
```

## Integration plan

1. **Protocol namespace** — expose HexenWorld protocol constants and wire structs without colliding with Hexen II's protocol header.
2. **Server bootstrap parser** — parse `svc_serverdata`, negotiate protocol 24/25/26/100, and reject unsupported versions explicitly.
3. **Precache handshake** — implement the HexenWorld `soundlist`, `modellist`, `prespawn`, `spawn`, and `begin` sequence over the integrated netchan.
4. **Client state adapter** — map HexenWorld player state, packet entities, static entities, stats, and lightstyles into Hexenwail's existing client/render structures rather than restoring the old renderer.
5. **Prediction and input** — integrate `pmove`, usercmd transmission, delta sequence selection, spectator state, and the 72 Hz physics cadence.
6. **Effects and presentation** — route HexenWorld temporary entities, effects, skins, status information, and downloads through the maintained Hexenwail subsystems.
7. **Server discovery** — query `hwmaster` from the unified server browser; the address supplied above is a master endpoint, not a playable server.
8. **Automated smoke** — run `hwsv` plus a headless integrated client and assert connection, bootstrap, spawn, and sustained packet exchange.
9. **Packaging and CI** — keep HexenWorld networking enabled in the normal Hexenwail package and gate both `.#nixos` and `.#hwsv` through Nix builds.

## Current limitation

The transport and netchan are live, but HexenWorld server-message parsing is not implemented yet. The client therefore cannot enter or render a remote map in this PR's current state.

Related: #35
