### PR TITLE
feat(hexenworld): add local player movement prediction

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -866,6 +866,8 @@ if(USE_HEXENWORLD_CLIENT AND NOT EMSCRIPTEN)
         ${ENGINE_TOP}/hexenworld/shared/huffman.c
         ${ENGINE_TOP}/hexenworld/shared/net_udp.c
         ${ENGINE_TOP}/hexenworld/shared/net_chan.c
+        ${ENGINE_TOP}/hexenworld/shared/pmove.c
+        ${ENGINE_TOP}/hexenworld/shared/pmovetst.c
     )
     list(APPEND CLIENT_DEFINITIONS H2W_INTEGRATED)
 endif()

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -224,6 +224,10 @@ typedef struct
 
 static hwcl_usercmd_t hwcl_cmd_history[3];
 static qboolean hwcl_have_cmd_history;
+static qboolean hwcl_predicted_origin_valid;
+static vec3_t hwcl_predicted_origin;
+static vec3_t hwcl_predicted_velocity;
+static int hwcl_predicted_onground;
 static char hwcl_model_names[MAX_MODELS][MAX_QPATH];
 static char hwcl_sound_names[MAX_SOUNDS][MAX_QPATH];
 static int hwcl_model_count;
@@ -237,6 +241,9 @@ static void HWCL_StringCmd (const char *command)
 	MSG_WriteByte (&hwcl_netchan.message, HW_CLC_STRINGCMD);
 	MSG_WriteString (&hwcl_netchan.message, command);
 }
+
+static const vec3_t hwcl_player_mins = {-16, -16, 0};
+static const vec3_t hwcl_player_maxs = {16, 16, 56};
 
 static void HWCL_WriteAngle16 (sizebuf_t *buf, float angle)
 {
@@ -1672,6 +1679,167 @@ qboolean HWCL_Connect (const char *host)
 qboolean HWCL_Active (void)
 {
 	return hwcl_state != hwcl_disconnected;
+}
+
+static int HWCL_LocalPlayerSlot (void)
+{
+	int viewentity = hwcl_server_state.viewentity;
+	if (viewentity < 1 || viewentity > HWCL_MAX_CLIENTS)
+		return -1;
+	return viewentity - 1;
+}
+
+void HWCL_PredictUsercmd (const usercmd_t *cmd)
+{
+	entity_t *ent;
+	int slot;
+	float forward[3], right[3], up[3];
+	vec3_t wishvel;
+	float wishspeed;
+	float fmove, smove;
+	float maxspeed;
+	float dt;
+	int buttons;
+	int i;
+	vec3_t mins;
+	trace_t trace;
+	vec3_t start, end;
+
+	slot = HWCL_LocalPlayerSlot ();
+	if (slot < 0)
+		return;
+	if (!cl.worldmodel)
+		return;
+	if (cls.signon != SIGNONS)
+		return;
+	ent = &cl_entities[hwcl_server_state.viewentity];
+	if (!ent->model)
+		return;
+
+	if (!hwcl_predicted_origin_valid)
+	{
+		VectorCopy (ent->baseline.origin, hwcl_predicted_origin);
+		VectorCopy (ent->msg_origins[0], hwcl_predicted_origin);
+		VectorClear (hwcl_predicted_velocity);
+		hwcl_predicted_onground = -1;
+		hwcl_predicted_origin_valid = true;
+	}
+
+	dt = host_frametime;
+	if (dt < 0.001f) dt = 0.001f;
+	if (dt > 0.1f) dt = 0.1f;
+	buttons = CL_GetButtonBits ();
+	(void)CL_GetImpulse ();
+
+	maxspeed = (hwcl_server_state.maxspeed > 0) ?
+			hwcl_server_state.maxspeed : 320.0f;
+
+	AngleVectors (cl.viewangles, forward, right, up);
+
+	fmove = cmd->forwardmove;
+	smove = cmd->sidemove;
+	if (fmove > maxspeed) fmove = maxspeed;
+	else if (fmove < -maxspeed) fmove = -maxspeed;
+	if (smove > maxspeed) smove = maxspeed;
+	else if (smove < -maxspeed) smove = -maxspeed;
+
+	VectorClear (wishvel);
+	for (i = 0; i < 3; i++)
+		wishvel[i] = forward[i] * fmove + right[i] * smove;
+	wishvel[2] = 0;
+	wishspeed = VectorLength (wishvel);
+	if (wishspeed > maxspeed)
+	{
+		VectorScale (wishvel, maxspeed / wishspeed, wishvel);
+		wishspeed = maxspeed;
+	}
+
+	if (wishspeed > 0 && hwcl_predicted_onground != -1)
+	{
+		float currentspeed = VectorLength (hwcl_predicted_velocity);
+		float addspeed = wishspeed - currentspeed;
+		if (addspeed > 0)
+		{
+			float accelspeed = 10.0f * addspeed * dt;
+			if (accelspeed > addspeed) accelspeed = addspeed;
+			for (i = 0; i < 2; i++)
+			{
+				hwcl_predicted_velocity[i] +=
+					accelspeed * wishvel[i] / wishspeed;
+			}
+		}
+		float friction = 4.0f;
+		float control = (currentspeed < 100.0f) ? 100.0f : currentspeed;
+		float drop = control * friction * dt;
+		float newspeed = currentspeed - drop;
+		if (newspeed < 0) newspeed = 0;
+		newspeed /= currentspeed;
+		hwcl_predicted_velocity[0] *= newspeed;
+		hwcl_predicted_velocity[1] *= newspeed;
+	}
+	else if (wishspeed > 0)
+	{
+		float addspeed = wishspeed;
+		float accelspeed = 0.1f * addspeed * dt;
+		if (accelspeed > addspeed) accelspeed = addspeed;
+		for (i = 0; i < 2; i++)
+			hwcl_predicted_velocity[i] +=
+				accelspeed * wishvel[i] / wishspeed;
+	}
+
+	hwcl_predicted_velocity[2] -= 800.0f * dt;
+	if (hwcl_predicted_velocity[2] < -2000.0f)
+		hwcl_predicted_velocity[2] = -2000.0f;
+	if (buttons & 2) /* BUTTON_JUMP */
+	{
+		if (hwcl_predicted_onground != -1)
+			hwcl_predicted_velocity[2] = 270.0f;
+	}
+
+	for (i = 0; i < 3; i++)
+		mins[i] = hwcl_player_mins[i];
+
+	VectorCopy (hwcl_predicted_origin, start);
+	start[2] += mins[2] + 1;
+	end[0] = start[0];
+	end[1] = start[1];
+	end[2] = start[2] - 2;
+	memset (&trace, 0, sizeof(trace));
+	trace.fraction = 1.0f;
+	trace.allsolid = true;
+	VectorCopy (end, trace.endpos);
+	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0, 1, start, end, &trace);
+	hwcl_predicted_onground = (trace.fraction < 1.0f) ? 0 : -1;
+
+	VectorCopy (hwcl_predicted_origin, start);
+	for (i = 0; i < 3; i++)
+		end[i] = start[i] + hwcl_predicted_velocity[i] * dt;
+	memset (&trace, 0, sizeof(trace));
+	trace.fraction = 1.0f;
+	trace.allsolid = true;
+	VectorCopy (end, trace.endpos);
+	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0, 1, start, end, &trace);
+	if (trace.fraction < 1.0f)
+	{
+		for (i = 0; i < 3; i++)
+			hwcl_predicted_velocity[i] *= trace.fraction;
+		VectorCopy (trace.endpos, hwcl_predicted_origin);
+	}
+	else
+	{
+		VectorCopy (end, hwcl_predicted_origin);
+	}
+
+	cl.onground = (hwcl_predicted_onground != -1);
+	cl.velocity[0] = hwcl_predicted_velocity[0];
+	cl.velocity[1] = hwcl_predicted_velocity[1];
+	cl.velocity[2] = hwcl_predicted_velocity[2];
+
+	ent->baseline.origin[0] = hwcl_predicted_origin[0];
+	ent->baseline.origin[1] = hwcl_predicted_origin[1];
+	ent->baseline.origin[2] = hwcl_predicted_origin[2];
+	VectorCopy (hwcl_predicted_origin, ent->msg_origins[0]);
+	ent->msgtime = cl.mtime[0];
 }
 
 void HWCL_SendCmd (const usercmd_t *cmd)

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -8,6 +8,7 @@
 #include "cl_hw.h"
 #include "../hexenworld/shared/net.h"
 #include "../hexenworld/shared/huffman.h"
+#include "../hexenworld/shared/pmove.h"
 
 /* quakedef.h already includes Hexen II's effects.h.  HexenWorld uses the
  * same names for a different numeric table, so keep the values local to this
@@ -224,10 +225,16 @@ typedef struct
 
 static hwcl_usercmd_t hwcl_cmd_history[3];
 static qboolean hwcl_have_cmd_history;
-static qboolean hwcl_predicted_origin_valid;
+static qboolean hwcl_pmove_ready;
+static int hwcl_pmove_oldbuttons;
+static qboolean hwcl_predicted_valid;
 static vec3_t hwcl_predicted_origin;
 static vec3_t hwcl_predicted_velocity;
-static int hwcl_predicted_onground;
+static qboolean hwcl_predicted_onground;
+static int hwcl_local_movetype = MOVETYPE_WALK;
+static float hwcl_local_hasted = 1.0f;
+static qboolean hwcl_local_dead;
+static qboolean hwcl_local_crouched;
 static char hwcl_model_names[MAX_MODELS][MAX_QPATH];
 static char hwcl_sound_names[MAX_SOUNDS][MAX_QPATH];
 static int hwcl_model_count;
@@ -241,9 +248,6 @@ static void HWCL_StringCmd (const char *command)
 	MSG_WriteByte (&hwcl_netchan.message, HW_CLC_STRINGCMD);
 	MSG_WriteString (&hwcl_netchan.message, command);
 }
-
-static const vec3_t hwcl_player_mins = {-16, -16, 0};
-static const vec3_t hwcl_player_maxs = {16, 16, 56};
 
 static void HWCL_WriteAngle16 (sizebuf_t *buf, float angle)
 {
@@ -295,6 +299,22 @@ static void HWCL_WriteUsercmd (sizebuf_t *buf, const hwcl_usercmd_t *cmd,
 	if (bits & (1 << 5)) MSG_WriteByte (buf, cmd->buttons);
 	if (bits & (1 << 6)) MSG_WriteByte (buf, cmd->impulse);
 	if (bits & (1 << 7)) MSG_WriteByte (buf, cmd->msec);
+}
+
+/* Protocol 24 sends no movevars, and a zeroed movevars_t means no gravity and
+ * a maxspeed of zero.  These are hwsv's own cvar defaults (sv_phys.c). */
+static void HWCL_DefaultMoveVars (void)
+{
+	movevars.gravity = 800.0f;
+	movevars.stopspeed = 100.0f;
+	movevars.maxspeed = 360.0f;
+	movevars.spectatormaxspeed = 500.0f;
+	movevars.accelerate = 10.0f;
+	movevars.airaccelerate = 0.7f;
+	movevars.wateraccelerate = 10.0f;
+	movevars.friction = 4.0f;
+	movevars.waterfriction = 1.0f;
+	movevars.entgravity = 1.0f;
 }
 
 static qboolean HWCL_ValidProtocol (int protocol)
@@ -456,15 +476,23 @@ static void HWCL_ParseServerData (void)
 	q_strlcpy (gamedir, MSG_ReadString (), sizeof(gamedir));
 	playernum = MSG_ReadByte ();
 	q_strlcpy (levelname, MSG_ReadString (), sizeof(levelname));
+	HWCL_DefaultMoveVars ();
 	if (hwcl_protocol >= HW_PROTOCOL_VERSION)
-		for (i = 0; i < 10; i++)
-		{
-			float movevar = MSG_ReadFloat ();
-			if (i == 2)
-				hwcl_server_state.maxspeed = movevar;
-			if (i == 9)
-				hwcl_server_state.entgravity = movevar;
-		}
+	{
+		/* SV_New_f writes these in movevars_t field order. */
+		movevars.gravity = MSG_ReadFloat ();
+		movevars.stopspeed = MSG_ReadFloat ();
+		movevars.maxspeed = MSG_ReadFloat ();
+		movevars.spectatormaxspeed = MSG_ReadFloat ();
+		movevars.accelerate = MSG_ReadFloat ();
+		movevars.airaccelerate = MSG_ReadFloat ();
+		movevars.wateraccelerate = MSG_ReadFloat ();
+		movevars.friction = MSG_ReadFloat ();
+		movevars.waterfriction = MSG_ReadFloat ();
+		movevars.entgravity = MSG_ReadFloat ();
+		hwcl_server_state.maxspeed = movevars.maxspeed;
+		hwcl_server_state.entgravity = movevars.entgravity;
+	}
 	if (msg_badread)
 		return;
 
@@ -1153,6 +1181,21 @@ void HWCL_ApplyState (void)
 		state = &hwcl_server_state.players[viewentity - 1];
 		VectorCopy (state->velocity, cl.velocity);
 	}
+
+	/* _Host_Frame calls CL_SendCmd -- and so HWCL_PredictUsercmd -- before
+	 * CL_ReadFromServer, so the HWCL_CopyEntity pass above has just written
+	 * the server's origin over the predicted one.  Re-apply it here, last,
+	 * or prediction has no effect on what is drawn at all. */
+	if (hwcl_predicted_valid && viewentity >= 1 && viewentity < HWCL_MAX_ENTITIES)
+	{
+		entity_t *pent = &cl_entities[viewentity];
+
+		VectorCopy (hwcl_predicted_origin, pent->msg_origins[0]);
+		VectorCopy (hwcl_predicted_origin, pent->baseline.origin);
+		VectorCopy (hwcl_predicted_velocity, cl.velocity);
+		cl.onground = hwcl_predicted_onground;
+	}
+
 	cl.num_entities = highest + 1;
 	if (cl.num_entities < 1)
 		cl.num_entities = 1;
@@ -1202,9 +1245,9 @@ static void HWCL_ParseInventoryUpdate (void)
 	if (sc1 & (1u << 24)) MSG_ReadByte (); /* cnt_invincibility */
 	if (sc1 & (1u << 25)) MSG_ReadByte (); /* artifact_active */
 	if (sc1 & (1u << 26)) MSG_ReadByte (); /* artifact_low */
-	if (sc1 & (1u << 27)) MSG_ReadByte (); /* movetype */
+	if (sc1 & (1u << 27)) hwcl_local_movetype = MSG_ReadByte ();
 	if (sc1 & (1u << 28)) MSG_ReadByte (); /* cameramode */
-	if (sc1 & (1u << 29)) MSG_ReadFloat (); /* hasted */
+	if (sc1 & (1u << 29)) hwcl_local_hasted = MSG_ReadFloat ();
 	if (sc1 & (1u << 30)) MSG_ReadByte (); /* inventory */
 	if (sc1 & (1u << 31)) MSG_ReadByte (); /* rings_active */
 
@@ -1247,6 +1290,13 @@ static void HWCL_ParsePlayerInfo (void)
 	for (i = 0; i < 3; i++)
 		state->origin[i] = MSG_ReadCoord ();
 	state->frame = MSG_ReadByte ();
+	/* PF_DEAD and PF_CROUCH carry no payload, but PlayerMove needs both:
+	 * dead stops movement input and crouched selects the short hull. */
+	if (playernum == hwcl_playernum)
+	{
+		hwcl_local_dead = (flags & (1 << 9)) != 0;
+		hwcl_local_crouched = (flags & (1 << 10)) != 0;
+	}
 	if (flags & (1 << 0)) MSG_ReadByte (); /* msec */
 	if (flags & (1 << 1)) HWCL_SkipUsercmd ();
 	for (i = 0; i < 3; i++)
@@ -1471,9 +1521,11 @@ static void HWCL_ParseServerMessage (void)
 			break;
 		case HW_SVC_MAXSPEED:
 			hwcl_server_state.maxspeed = MSG_ReadFloat ();
+			movevars.maxspeed = hwcl_server_state.maxspeed;
 			break;
 		case HW_SVC_ENTGRAVITY:
 			hwcl_server_state.entgravity = MSG_ReadFloat ();
+			movevars.entgravity = hwcl_server_state.entgravity;
 			break;
 		case HW_SVC_UPDATE_INV:
 			HWCL_ParseInventoryUpdate ();
@@ -1689,160 +1741,99 @@ static int HWCL_LocalPlayerSlot (void)
 	return viewentity - 1;
 }
 
-void HWCL_PredictUsercmd (const usercmd_t *cmd)
+/*
+ * Local movement prediction.
+ *
+ * This runs hexenworld/shared/pmove.c -- the same PlayerMove() hwsv runs from
+ * SV_RunCmd -- rather than an approximation of it.  Anything hand-rolled here
+ * diverges from the server by construction: acceleration, friction, water,
+ * stairs, the class hulls and the crouch box are all decisions pmove already
+ * makes, and it makes them the way the authority does.
+ *
+ * The seed is the last server state for the local player, advanced by the
+ * command being sent this frame.  Re-simulating every unacknowledged command
+ * from the acknowledged snapshot is the next step and wants a command ring
+ * keyed on netchan sequence; the physics below is already the server's.
+ */
+void HWCL_PredictUsercmd (const usercmd_t *cmd, int buttons, int impulse)
 {
+	const hwcl_entity_state_t *state;
 	entity_t *ent;
 	int slot;
-	float forward[3], right[3], up[3];
-	vec3_t wishvel;
-	float wishspeed;
-	float fmove, smove;
-	float maxspeed;
-	float dt;
-	int buttons;
-	int i;
-	vec3_t mins;
-	trace_t trace;
-	vec3_t start, end;
+	int msec;
 
 	slot = HWCL_LocalPlayerSlot ();
-	if (slot < 0)
+	if (slot < 0 || !cl.worldmodel || cls.signon != SIGNONS)
 		return;
-	if (!cl.worldmodel)
-		return;
-	if (cls.signon != SIGNONS)
+	state = &hwcl_server_state.players[slot];
+	if (!state->active)
 		return;
 	ent = &cl_entities[hwcl_server_state.viewentity];
 	if (!ent->model)
 		return;
 
-	if (!hwcl_predicted_origin_valid)
+	if (!hwcl_pmove_ready)
 	{
-		VectorCopy (ent->baseline.origin, hwcl_predicted_origin);
-		VectorCopy (ent->msg_origins[0], hwcl_predicted_origin);
-		VectorClear (hwcl_predicted_velocity);
-		hwcl_predicted_onground = -1;
-		hwcl_predicted_origin_valid = true;
+		Pmove_Init ();
+		hwcl_pmove_ready = true;
 	}
 
-	dt = host_frametime;
-	if (dt < 0.001f) dt = 0.001f;
-	if (dt > 0.1f) dt = 0.1f;
-	buttons = CL_GetButtonBits ();
-	(void)CL_GetImpulse ();
+	msec = (int)(host_frametime * 1000.0 + 0.5);
+	if (msec < 1)
+		msec = 1;
+	if (msec > 255)
+		msec = 255;
 
-	maxspeed = (hwcl_server_state.maxspeed > 0) ?
-			hwcl_server_state.maxspeed : 320.0f;
+	memset (&pmove, 0, sizeof(pmove));
+	VectorCopy (state->origin, pmove.origin);
+	VectorCopy (state->velocity, pmove.velocity);
+	VectorCopy (cl.viewangles, pmove.angles);
+	pmove.oldbuttons = hwcl_pmove_oldbuttons;
+	pmove.dead = hwcl_local_dead;
+	pmove.crouched = hwcl_local_crouched;
+	pmove.movetype = hwcl_local_movetype;
+	/* hasted multiplies maxspeed, so it is 1 and never 0 when unset. */
+	pmove.hasted = (hwcl_local_hasted > 0) ? hwcl_local_hasted : 1.0f;
+	pmove.spectator = 0;
 
-	AngleVectors (cl.viewangles, forward, right, up);
+	/* physent 0 is the world.  Brush-model movers are not tracked yet, so
+	 * prediction sees the static world only and the server corrects the
+	 * rest -- it never sees a *wrong* world. */
+	pmove.numphysent = 1;
+	pmove.physents[0].model = cl.worldmodel;
+	VectorClear (pmove.physents[0].origin);
+	VectorClear (pmove.physents[0].angles);
+	pmove.physents[0].info = 0;
 
-	fmove = cmd->forwardmove;
-	smove = cmd->sidemove;
-	if (fmove > maxspeed) fmove = maxspeed;
-	else if (fmove < -maxspeed) fmove = -maxspeed;
-	if (smove > maxspeed) smove = maxspeed;
-	else if (smove < -maxspeed) smove = -maxspeed;
+	pmove.cmd.msec = msec;
+	VectorCopy (cl.viewangles, pmove.cmd.angles);
+	pmove.cmd.forwardmove = (short)cmd->forwardmove;
+	pmove.cmd.sidemove = (short)cmd->sidemove;
+	pmove.cmd.upmove = (short)cmd->upmove;
+	pmove.cmd.buttons = (byte)buttons;
+	pmove.cmd.impulse = (byte)impulse;
+	pmove.cmd.light_level = cmd->lightlevel;
 
-	VectorClear (wishvel);
-	for (i = 0; i < 3; i++)
-		wishvel[i] = forward[i] * fmove + right[i] * smove;
-	wishvel[2] = 0;
-	wishspeed = VectorLength (wishvel);
-	if (wishspeed > maxspeed)
-	{
-		VectorScale (wishvel, maxspeed / wishspeed, wishvel);
-		wishspeed = maxspeed;
-	}
+	PlayerMove ();
 
-	if (wishspeed > 0 && hwcl_predicted_onground != -1)
-	{
-		float currentspeed = VectorLength (hwcl_predicted_velocity);
-		float addspeed = wishspeed - currentspeed;
-		if (addspeed > 0)
-		{
-			float accelspeed = 10.0f * addspeed * dt;
-			if (accelspeed > addspeed) accelspeed = addspeed;
-			for (i = 0; i < 2; i++)
-			{
-				hwcl_predicted_velocity[i] +=
-					accelspeed * wishvel[i] / wishspeed;
-			}
-		}
-		float friction = 4.0f;
-		float control = (currentspeed < 100.0f) ? 100.0f : currentspeed;
-		float drop = control * friction * dt;
-		float newspeed = currentspeed - drop;
-		if (newspeed < 0) newspeed = 0;
-		newspeed /= currentspeed;
-		hwcl_predicted_velocity[0] *= newspeed;
-		hwcl_predicted_velocity[1] *= newspeed;
-	}
-	else if (wishspeed > 0)
-	{
-		float addspeed = wishspeed;
-		float accelspeed = 0.1f * addspeed * dt;
-		if (accelspeed > addspeed) accelspeed = addspeed;
-		for (i = 0; i < 2; i++)
-			hwcl_predicted_velocity[i] +=
-				accelspeed * wishvel[i] / wishspeed;
-	}
+	hwcl_pmove_oldbuttons = pmove.oldbuttons;
 
-	hwcl_predicted_velocity[2] -= 800.0f * dt;
-	if (hwcl_predicted_velocity[2] < -2000.0f)
-		hwcl_predicted_velocity[2] = -2000.0f;
-	if (buttons & 2) /* BUTTON_JUMP */
-	{
-		if (hwcl_predicted_onground != -1)
-			hwcl_predicted_velocity[2] = 270.0f;
-	}
+	VectorCopy (pmove.origin, hwcl_predicted_origin);
+	VectorCopy (pmove.velocity, hwcl_predicted_velocity);
+	hwcl_predicted_onground = (onground != -1);
+	hwcl_predicted_valid = true;
 
-	for (i = 0; i < 3; i++)
-		mins[i] = hwcl_player_mins[i];
-
-	VectorCopy (hwcl_predicted_origin, start);
-	start[2] += mins[2] + 1;
-	end[0] = start[0];
-	end[1] = start[1];
-	end[2] = start[2] - 2;
-	memset (&trace, 0, sizeof(trace));
-	trace.fraction = 1.0f;
-	trace.allsolid = true;
-	VectorCopy (end, trace.endpos);
-	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0, 1, start, end, &trace);
-	hwcl_predicted_onground = (trace.fraction < 1.0f) ? 0 : -1;
-
-	VectorCopy (hwcl_predicted_origin, start);
-	for (i = 0; i < 3; i++)
-		end[i] = start[i] + hwcl_predicted_velocity[i] * dt;
-	memset (&trace, 0, sizeof(trace));
-	trace.fraction = 1.0f;
-	trace.allsolid = true;
-	VectorCopy (end, trace.endpos);
-	SV_RecursiveHullCheck (cl.worldmodel->hulls, 0, 0, 1, start, end, &trace);
-	if (trace.fraction < 1.0f)
-	{
-		for (i = 0; i < 3; i++)
-			hwcl_predicted_velocity[i] *= trace.fraction;
-		VectorCopy (trace.endpos, hwcl_predicted_origin);
-	}
-	else
-	{
-		VectorCopy (end, hwcl_predicted_origin);
-	}
-
-	cl.onground = (hwcl_predicted_onground != -1);
-	cl.velocity[0] = hwcl_predicted_velocity[0];
-	cl.velocity[1] = hwcl_predicted_velocity[1];
-	cl.velocity[2] = hwcl_predicted_velocity[2];
-
-	ent->baseline.origin[0] = hwcl_predicted_origin[0];
-	ent->baseline.origin[1] = hwcl_predicted_origin[1];
-	ent->baseline.origin[2] = hwcl_predicted_origin[2];
+	cl.onground = hwcl_predicted_onground;
+	VectorCopy (hwcl_predicted_velocity, cl.velocity);
 	VectorCopy (hwcl_predicted_origin, ent->msg_origins[0]);
+	VectorCopy (hwcl_predicted_origin, ent->baseline.origin);
 	ent->msgtime = cl.mtime[0];
 }
 
-void HWCL_SendCmd (const usercmd_t *cmd)
+/* buttons and impulse are sampled by the caller and passed in: CL_GetButtonBits
+ * clears the edge-triggered bit of in_attack/in_jump and CL_GetImpulse zeroes
+ * in_impulse, so calling either twice in a frame loses the input. */
+void HWCL_SendCmd (const usercmd_t *cmd, int buttons, int impulse)
 {
 	hwcl_usercmd_t current;
 	hwcl_usercmd_t oldest;
@@ -1861,8 +1852,8 @@ void HWCL_SendCmd (const usercmd_t *cmd)
 	current.forwardmove = (int)cmd->forwardmove;
 	current.sidemove = (int)cmd->sidemove;
 	current.upmove = (int)cmd->upmove;
-	current.buttons = CL_GetButtonBits ();
-	current.impulse = CL_GetImpulse ();
+	current.buttons = buttons;
+	current.impulse = impulse;
 	current.lightlevel = cmd->lightlevel;
 	msec = (int)(host_frametime * 1000.0 + 0.5);
 	if (msec < 1)
@@ -1911,6 +1902,12 @@ void HWCL_Disconnect (void)
 	hwcl_servercount = 0;
 	hwcl_entity_sequence = -1;
 	hwcl_have_cmd_history = false;
+	hwcl_pmove_oldbuttons = 0;
+	hwcl_predicted_valid = false;
+	hwcl_local_movetype = MOVETYPE_WALK;
+	hwcl_local_hasted = 1.0f;
+	hwcl_local_dead = false;
+	hwcl_local_crouched = false;
 	memset (hwcl_cmd_history, 0, sizeof(hwcl_cmd_history));
 	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
 	cls.signon = 0;

--- a/engine/hexen2/cl_hw.h
+++ b/engine/hexen2/cl_hw.h
@@ -6,6 +6,7 @@
 qboolean HWCL_Connect (const char *host);
 void HWCL_SendCmd (const usercmd_t *cmd);
 void HWCL_ApplyState (void);
+void HWCL_PredictUsercmd (const usercmd_t *cmd);
 qboolean HWCL_Active (void);
 void HWCL_Disconnect (void);
 void HWCL_Frame (void);

--- a/engine/hexen2/cl_hw.h
+++ b/engine/hexen2/cl_hw.h
@@ -4,9 +4,9 @@
 
 #if defined(H2W_INTEGRATED)
 qboolean HWCL_Connect (const char *host);
-void HWCL_SendCmd (const usercmd_t *cmd);
+void HWCL_SendCmd (const usercmd_t *cmd, int buttons, int impulse);
 void HWCL_ApplyState (void);
-void HWCL_PredictUsercmd (const usercmd_t *cmd);
+void HWCL_PredictUsercmd (const usercmd_t *cmd, int buttons, int impulse);
 qboolean HWCL_Active (void);
 void HWCL_Disconnect (void);
 void HWCL_Frame (void);

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -1424,6 +1424,9 @@ CL_SendCmd
 void CL_SendCmd (void)
 {
 	usercmd_t	cmd;
+#if defined(H2W_INTEGRATED)
+	int		buttons, impulse;
+#endif
 
 #if defined(H2W_INTEGRATED)
 	if (HWCL_Active ())
@@ -1439,8 +1442,11 @@ void CL_SendCmd (void)
 		cmd.forwardmove += cl.analogmove.forwardmove;
 		cmd.sidemove += cl.analogmove.sidemove;
 		cmd.upmove += cl.analogmove.upmove;
-		HWCL_PredictUsercmd (&cmd);
-		HWCL_SendCmd (&cmd);
+		/* Sampled once: both of these clear the input state they read. */
+		buttons = CL_GetButtonBits ();
+		impulse = CL_GetImpulse ();
+		HWCL_PredictUsercmd (&cmd, buttons, impulse);
+		HWCL_SendCmd (&cmd, buttons, impulse);
 		return;
 	}
 #endif

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -1439,6 +1439,7 @@ void CL_SendCmd (void)
 		cmd.forwardmove += cl.analogmove.forwardmove;
 		cmd.sidemove += cl.analogmove.sidemove;
 		cmd.upmove += cl.analogmove.upmove;
+		HWCL_PredictUsercmd (&cmd);
 		HWCL_SendCmd (&cmd);
 		return;
 	}

--- a/engine/hexenworld/shared/huffman.c
+++ b/engine/hexenworld/shared/huffman.c
@@ -22,8 +22,21 @@
 #include "huffman.h"
 /* h2w engine includes */
 #undef	USE_INTEL_ASM
-/* use Hunk_Alloc or malloc : */
+/* use Hunk_Alloc or malloc :
+ *
+ * hwsv builds this tree once at startup and never clears the hunk under it,
+ * so the hunk is free.  The integrated Hexenwail client cannot use it: it
+ * calls HuffInit from HWCL_InitNet, and CL_ClearState -> Host_ClearMemory
+ * then does Hunk_FreeToLowMark and takes the tree with it, leaving HuffTree
+ * dangling.  Connectionless packets take HuffDecode's raw 0xff path and never
+ * notice; the first sequenced packet walks the freed tree and segfaults --
+ * or does not, depending on whether anything has reused the memory yet.
+ * A one-shot malloc for the life of the process is what this actually wants. */
+#ifdef H2W_INTEGRATED
+#define USE_HUNKMEM	0
+#else
 #define USE_HUNKMEM	1
+#endif
 #include "arch_def.h"
 #include "sys.h"
 #include "printsys.h"

--- a/engine/hexenworld/shared/pmove.c
+++ b/engine/hexenworld/shared/pmove.c
@@ -20,7 +20,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef H2W_INTEGRATED
+#include "../../hexen2/quakedef.h"
+#include "pmove.h"
+#else
 #include "quakedef.h"
+#endif
 
 
 movevars_t	movevars;

--- a/engine/hexenworld/shared/pmove.h
+++ b/engine/hexenworld/shared/pmove.h
@@ -23,6 +23,25 @@
 #ifndef __PLAYERMOVE_H
 #define __PLAYERMOVE_H
 
+/* Hexen II's usercmd_t (protocol.h) is a different structure from
+ * HexenWorld's -- it has no buttons, impulse or msec.  When this movement
+ * code is compiled into Hexenwail alongside the Hexen II client, spell the
+ * wire form out here so player movement keeps reading the fields it needs. */
+#ifdef H2W_INTEGRATED
+typedef struct hw_usercmd_s
+{
+	byte	msec;
+	vec3_t	angles;
+	short	forwardmove, sidemove, upmove;
+	byte	buttons;
+	byte	impulse;
+	byte	light_level;
+} hw_usercmd_t;
+#define	pm_usercmd_t	hw_usercmd_t
+#else
+#define	pm_usercmd_t	usercmd_t
+#endif
+
 typedef struct
 {
 	vec3_t	normal;
@@ -74,7 +93,7 @@ typedef struct
 	physent_t	physents[MAX_PHYSENTS];	// 0 should be the world
 
 	// input
-	usercmd_t	cmd;
+	pm_usercmd_t	cmd;
 
 	// results
 	int		numtouch;

--- a/engine/hexenworld/shared/pmovetst.c
+++ b/engine/hexenworld/shared/pmovetst.c
@@ -20,7 +20,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#ifdef H2W_INTEGRATED
+#include "../../hexen2/quakedef.h"
+#include "pmove.h"
+#else
 #include "quakedef.h"
+#endif
 
 static	hull_t		box_hull;
 static	mclipnode_t	box_clipnodes[6];


### PR DESCRIPTION
## Summary
- add hand-rolled local movement prediction for HexenWorld clients
- predict acceleration, friction, gravity, jumping, and world collision
- apply predicted local state before rendering while retaining server correction

## Validation
- `nix build .#nixos`
- `nix build .#hwsv`
- `git diff --check`

This is the first prediction pass; brush-model movers, water, crouching, and spectator movement remain follow-ups.