### PR TITLE
fix(hexenworld): mount the server's gamedir on connect

### DIFF
--- a/engine/h2shared/quakefs.c
+++ b/engine/h2shared/quakefs.c
@@ -1132,6 +1132,14 @@ void FS_Gamedir (const char *dir)
 	 * whatever the previous mod it was running and went back to
 	 * pure hw. weird.. do as he wishes anyway and adjust our variables. */
 		set_hw_dir ();
+#elif defined(H2W_INTEGRATED)
+	/* The HexenWorld client lives inside a plain Hexenwail launch whose
+	 * base searchpaths were built for data1 (+ portals).  The H2W server
+	 * keeps hw in its base because it was started with -game hw; this
+	 * client was not, so the server-directed gamedir must be mounted now
+	 * or every model/sound/map it references (hw/pak4.pak especially) is
+	 * unresolvable -- the world itself included. */
+		FS_AddGameDirectory (dir, false);
 #else	/* hexen2 case: */
 	/* hw is reserved for hexenworld only. hexen2 shouldn't use it */
 		Con_Printf ("WARNING: Gamedir not set to hw :\n"

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -477,6 +477,15 @@ static void HWCL_ParseServerData (void)
 	hwcl_entity_sequence = -1;
 	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
 	q_strlcpy (gamedir, MSG_ReadString (), sizeof(gamedir));
+	/* The server's gamedir names where its content lives on disk.  Mount it
+	 * before anything references a model or sound, exactly as the original
+	 * HexenWorld client did here -- without it, hw/pak4.pak is invisible and
+	 * every map/model the signon names is reported unavailable. */
+	if (q_strcasecmp(fs_gamedir_nopath, gamedir))
+	{
+		Con_Printf ("HexenWorld server set the gamedir to %s\n", gamedir);
+		FS_Gamedir (gamedir);
+	}
 	playernum = MSG_ReadByte ();
 	q_strlcpy (levelname, MSG_ReadString (), sizeof(levelname));
 	HWCL_DefaultMoveVars ();


### PR DESCRIPTION
## Summary
The integrated HexenWorld client read the server's gamedir in `CL_ParseServerData` but never mounted it. Against a Hexenwail `hwsv` this meant every reference into `hw/pak4.pak` failed: at signon the client printed forty-plus `model N unavailable` lines, the world map itself (`maps/hwdm1.bsp`) came back unavailable, and none of the HexenWorld-specific monsters could load.

- `FS_Gamedir` now treats the reserved `hw` gamedir as mountable for the integrated client build (`H2W_INTEGRATED`), since a plain Hexenwail launch built its base searchpaths for `data1` and has no `hw` mounted. The `H2W` server path is unchanged.
- `CL_ParseServerData` applies the server-announced gamedir before anything is loaded, matching the original HexenWorld client's ordering.

## Verification
- `nix build /home/josh/tmp/claudedir/uhexen2/.claude/worktrees/hw-gamedir#nixos /home/josh/tmp/claudedir/uhexen2/.claude/worktrees/hw-gamedir#hwsv`
- `git diff --check`
- Local `hwsv -game hw` plus offscreen `glhexen2`, against the installed data:
  - `+map hwdm1`: `HexenWorld server set the gamedir to hw`, `World VBO: 23638 verts`, signon complete, **0 unavailable models** (previously ~40).
  - `+map demo1`: gamedir still applied, **0 unavailable**, signon complete.

Tracks `uhexen2-6g8q.8`.