### PR TITLE
feat(menu): join HexenWorld servers from the multiplayer menu

### DIFF
--- a/engine/hexen2/menu.c
+++ b/engine/hexen2/menu.c
@@ -7176,12 +7176,17 @@ static void M_Quit_Draw (void)
 //=============================================================================
 
 static int	lanConfig_cursor = -1;
-static const int	lanConfig_cursor_table[] = {100, 120, 140, 172};
-#define NUM_LANCONFIG_CMDS	4
+static const int	lanConfig_cursor_table[] = {100, 120, 140, 172, 188};
+#define NUM_LANCONFIG_CMDS	5
 
 static int	lanConfig_port;
 static char	lanConfig_portname[6];
 static char	lanConfig_joinname[30];
+/* 0 = Hexen II protocol 19 (the legacy TCP/IP master-server join), 1 = the
+ * HexenWorld QuakeWorld-style join.  When set, the join field issues
+ * connect hw://<addr> instead of connect <addr>, so bare ip:port addresses
+ * reach HexenWorld servers without the player typing the scheme. */
+static qboolean	lanConfig_hwjoin;
 
 static void M_Menu_LanConfig_f (void)
 {
@@ -7256,6 +7261,9 @@ static void M_LanConfig_Draw (void)
 		M_Print (basex, 156, "Join game at:");
 		M_DrawTextBox (basex, lanConfig_cursor_table[3]-8, 30, 1);
 		M_Print (basex+8, lanConfig_cursor_table[3], lanConfig_joinname);
+
+		M_Print (basex, lanConfig_cursor_table[4],
+			 lanConfig_hwjoin ? "Join as: HexenWorld" : "Join as: Hexen II (TCP/IP)");
 	}
 	else
 	{
@@ -7338,7 +7346,17 @@ static void M_LanConfig_Key (int key)
 			m_return_onerror = true;
 			Key_SetDest (key_game);
 			m_state = m_none;
-			Cbuf_AddText ( va ("connect \"%s\"\n", lanConfig_joinname) );
+			if (lanConfig_hwjoin)
+				Cbuf_AddText ( va ("connect \"hw://%s\"\n", lanConfig_joinname) );
+			else
+				Cbuf_AddText ( va ("connect \"%s\"\n", lanConfig_joinname) );
+			break;
+		}
+
+		if (lanConfig_cursor == 4)
+		{
+			/* Protocol toggle: switching must not start a join. */
+			lanConfig_hwjoin = !lanConfig_hwjoin;
 			break;
 		}
 
@@ -7360,10 +7378,15 @@ static void M_LanConfig_Key (int key)
 		break;
 
 	case K_LEFTARROW:
-		if (lanConfig_cursor != 1 || !JoiningGame)
+		if (!JoiningGame || (lanConfig_cursor != 1 && lanConfig_cursor != 4))
 			break;
 
 		S_LocalSound ("raven/menu3.wav");
+		if (lanConfig_cursor == 4)
+		{
+			lanConfig_hwjoin = !lanConfig_hwjoin;
+			break;
+		}
 #if ENABLE_OLD_DEMO
 		if (gameflags & GAME_OLD_DEMO)
 		{
@@ -7379,10 +7402,15 @@ static void M_LanConfig_Key (int key)
 		break;
 
 	case K_RIGHTARROW:
-		if (lanConfig_cursor != 1 || !JoiningGame)
+		if (!JoiningGame || (lanConfig_cursor != 1 && lanConfig_cursor != 4))
 			break;
 
 		S_LocalSound ("raven/menu3.wav");
+		if (lanConfig_cursor == 4)
+		{
+			lanConfig_hwjoin = !lanConfig_hwjoin;
+			break;
+		}
 #if ENABLE_OLD_DEMO
 		if (gameflags & GAME_OLD_DEMO)
 		{
@@ -7424,7 +7452,7 @@ static void M_LanConfig_Key (int key)
 		}
 	}
 
-	if (StartingGame && lanConfig_cursor == 2)
+	if (StartingGame && lanConfig_cursor >= 2)
 	{
 		if (key == K_UPARROW)
 			lanConfig_cursor = 1;


### PR DESCRIPTION
## Summary
The multiplayer **Join Game** LAN-config screen gains a **"Join as:"** row. Choosing **HexenWorld** makes the existing join field emit `connect hw://<addr>` instead of the Hexen II `connect`, so a player can type a bare `ip:port` and reach a HexenWorld server straight from the main menu — no need to know the `hw://` scheme.

Targets the live HexenWorld scene (e.g. Darkravager's `168.138.68.8:26950`/`:26955`/`:26956`) — the same `connect hw://` path already proven in the headless smoke, now reachable from the menu.

## What changed (`engine/hexen2/menu.c`)
- New cursor row 4 on the Join Game screen: `Join as: HexenWorld` / `Join as: Hexen II (TCP/IP)`, toggled by Enter/left/right.
- Enter on the join field prefixes `hw://` when HexenWorld is selected.
- Starting-game cursor clamp and wrap follow the new row count; the row is only present in Join mode.

## Verification
- `nix build <wt>#nixos`, `git diff --check`.
- The exact emitted command — `connect "hw://127.0.0.1:26959"` — verified end-to-end against a local `hwsv -port 26959`: connection accepted, protocol 100, signon complete, player spawned.
- Interactive menu-drive under bare Xvfb could not be completed: SDL3 does not receive XTEST keyboard input on a WM-less display here (`in_debugkeys` confirms zero key events land). The row's draw/key logic is compile-checked and simple; a desktop / WM-based visual pass is still worthwhile.

## Notes
- HexenWorld servers on the default port (26950) can be joined by address alone; other ports (`:26956` etc.) are honored via the existing `hw://host:port` parse.
- This is the typed-address entry point; a HexenWorld **server browser** (master-server protocol) is the larger `uhexen2-6g8q.11` item and is still open.