### PR TITLE
Multiplayer: autodetect H2/HW and mount Siege content

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Software-renderer menu parity
         run: python3 tools/menu_soft_parity.py
 
+      # Data-free coverage for the unified multiplayer path. The harness
+      # extracts the production C functions rather than maintaining a Python
+      # reimplementation, then compiles them against narrow engine stubs.
+      - name: Multiplayer join and content-path regression
+        run: python3 tools/test_multiplayer_join.py
+
       # ARE_WE_IRONWAIL_YET.md carries a summary table over rows kept further
       # down the same file, and the two drift every time somebody flips a row
       # by hand.  The file records this happening in 2026-08-20 and twice on

--- a/USAGE.md
+++ b/USAGE.md
@@ -96,6 +96,34 @@ Options: `--scale 2|3|4` (default 4), `--upscaler realcugan|realesrgan` (default
 
 To launch a mod with portals data included: `glhexen2 -mod <modname>`
 
+## Multiplayer
+
+The multiplayer menu and the ordinary `connect` command automatically try the
+Hexen II protocol first, then try HexenWorld when the Hexen II server does not
+answer. Use `h2://address` or `hw://address` to force a protocol when needed;
+this fallback is bounded and an H2 rejection is not silently retried as HW.
+
+A vanilla HexenWorld install needs the retail `data1/pak0.pak` and
+`pak1.pak`, plus `hw/pak4.pak` from the [Hammer of Thyrion HexenWorld game
+data](https://uhexen2.sourceforge.net/download.html). HexenWorld servers
+advertise their game directory during signon. Hexenwail mounts `hw/` as the
+shared HW layer and puts the advertised mod above it, so Siege is still
+HexenWorld protocol rather than a third protocol.
+
+Siege is **not** contained entirely in `pak4.pak`. The upstream
+`hexenworld mods/siege.tgz` archive installs a `siege/` directory containing,
+at minimum, `hwprogs.dat`, the Siege maps (including `maps/siege.bsp`),
+models, sounds, menu graphics, and MIDI data. Keep that directory beside
+`hw/`; the server's advertised `siege` gamedir must be present on the client.
+The server can reference other maps or assets, so install the complete Siege
+archive rather than copying only `siege.bsp`. The client reports the missing
+path and leaves signon if a required world/model is unavailable instead of
+remaining behind the loading screen.
+
+When reporting a connection problem, include the console lines for `server set
+the gamedir`, `signon complete`, and any `HexenWorld missing` message. A
+successful join prints `signon complete`, followed by the first rendered world.
+
 ## Bundled gamecode
 
 Releases ship compiled gamecode (`progs.dat`, `progs2.dat`) beside the engine —

--- a/engine/h2shared/quakefs.c
+++ b/engine/h2shared/quakefs.c
@@ -1067,6 +1067,62 @@ add_pakfile:
 #endif
 }
 
+#ifdef H2W_INTEGRATED
+/* Keep the local game's paths alive, but out of the server's search order.
+ * Only temporary HW/mod entries above the base are freed on disconnect. */
+static searchpath_t *fs_hw_saved_paths;
+static char fs_hw_saved_game[MAX_QPATH];
+static char fs_hw_saved_gamedir[MAX_OSPATH], fs_hw_saved_userdir[MAX_OSPATH];
+static unsigned int fs_hw_saved_flags;
+
+qboolean FS_HWGamedir (const char *dir)
+{
+	const unsigned char *p = (const unsigned char *)dir;
+
+	/* A wire string must be one safe directory component, not a console
+	 * command, traversal, absolute path, or reserved local base directory. */
+	if (!*p || strlen(dir) >= MAX_QPATH || !strcmp(dir, ".") ||
+	    strstr(dir, "..") || !q_strcasecmp(dir, "data1") ||
+	    !q_strcasecmp(dir, "portals"))
+		return false;
+	for (; *p; p++)
+		if (!((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+		      (*p >= '0' && *p <= '9') || *p == '_' || *p == '-' || *p == '.'))
+			return false;
+
+	if (!fs_hw_saved_paths)
+	{
+		fs_hw_saved_paths = fs_searchpaths;
+		q_strlcpy (fs_hw_saved_game, fs_gamedir_nopath, sizeof(fs_hw_saved_game));
+		q_strlcpy (fs_hw_saved_gamedir, fs_gamedir, sizeof(fs_hw_saved_gamedir));
+		q_strlcpy (fs_hw_saved_userdir, fs_userdir, sizeof(fs_hw_saved_userdir));
+		fs_hw_saved_flags = gameflags;
+		fs_searchpaths = fs_base_searchpaths;
+	}
+	else
+		FS_UnwindSearchpaths (fs_base_searchpaths, false);
+	Cache_Flush ();
+	FS_AddGameDirectory ("hw", false);
+	if (q_strcasecmp(dir, "hw"))
+		FS_AddGameDirectory (dir, false);
+	return true;
+}
+
+void FS_HWRestore (void)
+{
+	if (!fs_hw_saved_paths)
+		return;
+	Cache_Flush ();
+	FS_UnwindSearchpaths (fs_base_searchpaths, false);
+	fs_searchpaths = fs_hw_saved_paths;
+	fs_hw_saved_paths = NULL;
+	gameflags = fs_hw_saved_flags;
+	q_strlcpy (fs_gamedir_nopath, fs_hw_saved_game, sizeof(fs_gamedir_nopath));
+	q_strlcpy (fs_gamedir, fs_hw_saved_gamedir, sizeof(fs_gamedir));
+	q_strlcpy (fs_userdir, fs_hw_saved_userdir, sizeof(fs_userdir));
+}
+#endif
+
 /*
 ================
 FS_Gamedir

--- a/engine/h2shared/quakefs.h
+++ b/engine/h2shared/quakefs.h
@@ -66,6 +66,12 @@ void FS_Init (void);
 void FS_Gamedir (const char *dir);
 	/* Sets the gamedir and path to a different directory. */
 
+#ifdef H2W_INTEGRATED
+qboolean FS_HWGamedir (const char *dir);
+void FS_HWRestore (void);
+	/* Temporary server-selected HW/mod paths; restore the local game on exit. */
+#endif
+
 
 /* file i/o within qfs */
 extern	long	fs_filesize;	/* size of the last file opened through QFS api */

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -171,6 +171,9 @@ static netadr_t hwcl_server;
 static char hwcl_server_name[HW_ADDRESS_MAX + 1];
 static netchan_t hwcl_netchan;
 static double hwcl_connect_time;
+static double hwcl_connect_started;
+static double hwcl_last_received;
+#define HWCL_CONNECT_TIMEOUT 15.0
 static qboolean hwcl_received_packet;
 static int hwcl_protocol;
 static int hwcl_servercount;
@@ -353,11 +356,11 @@ static void HWCL_LoadModels (void)
 			continue;
 		model = Mod_ForName (hwcl_model_names[i], false);
 		if (!model)
-		{
-			Con_DPrintf ("HexenWorld model %d unavailable: %s\n", i,
-					hwcl_model_names[i]);
-			continue;
-		}
+			Host_Error ("HexenWorld missing %s: %s\n"
+				"Install hw/pak4.pak and the server's %s mod assets under %s (or %s).\n"
+				"Siege additionally needs siege/maps/siege.bsp and its mod assets.",
+				i == 1 ? "world map" : "model", hwcl_model_names[i],
+				fs_gamedir_nopath, FS_GetBasedir (), FS_GetUserbase ());
 		cl.model_precache[i] = model;
 	}
 
@@ -366,11 +369,7 @@ static void HWCL_LoadModels (void)
 			player_models[i] = Mod_ForName (player_names[i], false);
 
 	if (!cl.model_precache[1])
-	{
-		Con_Printf ("HexenWorld world model unavailable: %s\n",
-				hwcl_model_names[1]);
-		return;
-	}
+		Host_Error ("HexenWorld server supplied no world map");
 
 	cl.worldmodel = cl_entities[0].model = cl.model_precache[1];
 	COM_FileBase (hwcl_model_names[1], cl.mapname, sizeof(cl.mapname));
@@ -471,6 +470,7 @@ static void HWCL_ParseServerData (void)
 {
 	int playernum;
 	char gamedir[MAX_QPATH];
+	const char *server_gamedir;
 	char levelname[1024];
 
 	hwcl_protocol = MSG_ReadLong ();
@@ -484,16 +484,13 @@ static void HWCL_ParseServerData (void)
 	hwcl_servercount = MSG_ReadLong ();
 	hwcl_entity_sequence = -1;
 	memset (&hwcl_server_state, 0, sizeof(hwcl_server_state));
-	q_strlcpy (gamedir, MSG_ReadString (), sizeof(gamedir));
-	/* The server's gamedir names where its content lives on disk.  Mount it
-	 * before anything references a model or sound, exactly as the original
-	 * HexenWorld client did here -- without it, hw/pak4.pak is invisible and
-	 * every map/model the signon names is reported unavailable. */
-	if (q_strcasecmp(fs_gamedir_nopath, gamedir))
-	{
-		Con_Printf ("HexenWorld server set the gamedir to %s\n", gamedir);
-		FS_Gamedir (gamedir);
-	}
+	server_gamedir = MSG_ReadString ();
+	if (msg_badread || strlen (server_gamedir) >= sizeof(gamedir))
+		Host_Error ("Invalid HexenWorld server game directory");
+	q_strlcpy (gamedir, server_gamedir, sizeof(gamedir));
+	if (!FS_HWGamedir (gamedir))
+		Host_Error ("Invalid HexenWorld server game directory: %s", gamedir);
+	Con_Printf ("HexenWorld server set the gamedir to %s\n", gamedir);
 	playernum = MSG_ReadByte ();
 	q_strlcpy (levelname, MSG_ReadString (), sizeof(levelname));
 	HWCL_DefaultMoveVars ();
@@ -536,6 +533,7 @@ static void HWCL_ParseServerData (void)
 			cl.maxclients * sizeof(*cl.scores), "hw_scores");
 	memset (cl.scores, 0, cl.maxclients * sizeof(*cl.scores));
 	cl.gametype = GAME_DEATHMATCH;
+	cl.viewheight = cl.crouch = 50;
 	cl.viewentity = hwcl_playernum + 1;
 	hwcl_server_state.viewentity = cl.viewentity;
 	if (hwcl_playernum >= 0 && hwcl_playernum < HWCL_MAX_CLIENTS)
@@ -693,6 +691,8 @@ static void HWCL_Changing (void)
 {
 	S_StopAllSounds (true);
 	cl.intermission = 0;
+	cls.signon = 0;
+	cl.worldmodel = NULL;
 	cls.state = ca_connected;	/* not active anymore, but not disconnected */
 	Con_Printf ("\nChanging map...\n");
 }
@@ -712,6 +712,8 @@ static void HWCL_Reconnect (void)
 	Con_Printf ("reconnecting...\n");
 	HWCL_Disconnect ();
 	hwcl_state = hwcl_connecting;
+	cls.state = ca_connected;
+	hwcl_connect_started = realtime;
 	HWCL_SendConnectPacket ();
 }
 
@@ -1352,6 +1354,11 @@ void HWCL_ApplyState (void)
 	{
 		state = &hwcl_server_state.players[viewentity - 1];
 		VectorCopy (state->velocity, cl.velocity);
+		cl.stats[STAT_WEAPONFRAME] = state->weaponframe;
+		/* HW origins are feet, and view height is implied by player flags,
+		 * not H2's SU_VIEWHEIGHT. Match the original HW client's camera. */
+		cl.viewheight = hwcl_spectator ? 50 :
+			(hwcl_local_crouched ? 24 : (hwcl_local_dead ? 8 : 50));
 	}
 
 	/* _Host_Frame calls CL_SendCmd -- and so HWCL_PredictUsercmd -- before
@@ -1389,49 +1396,51 @@ static void HWCL_ParseInventoryUpdate (void)
 	if (groups & 64) sc2 |= (unsigned int)MSG_ReadByte () << 16;
 	if (groups & 128) sc2 |= (unsigned int)MSG_ReadByte () << 24;
 
-	if (sc1 & (1u << 0)) MSG_ReadShort (); /* health */
-	if (sc1 & (1u << 1)) MSG_ReadByte (); /* level */
-	if (sc1 & (1u << 2)) MSG_ReadByte (); /* intelligence */
-	if (sc1 & (1u << 3)) MSG_ReadByte (); /* wisdom */
-	if (sc1 & (1u << 4)) MSG_ReadByte (); /* strength */
-	if (sc1 & (1u << 5)) MSG_ReadByte (); /* dexterity */
+	/* These fields drive both the HUD and view code. Discarding health leaves
+	 * the live player at zero HP and V_CalcViewRoll tilts the camera 80 degrees. */
+	if (sc1 & (1u << 0)) cl.v.health = MSG_ReadShort ();
+	if (sc1 & (1u << 1)) cl.v.level = MSG_ReadByte ();
+	if (sc1 & (1u << 2)) cl.v.intelligence = MSG_ReadByte ();
+	if (sc1 & (1u << 3)) cl.v.wisdom = MSG_ReadByte ();
+	if (sc1 & (1u << 4)) cl.v.strength = MSG_ReadByte ();
+	if (sc1 & (1u << 5)) cl.v.dexterity = MSG_ReadByte ();
 	/* Bit 6 is SC1_TELEPORT_TIME in the protocol header, but this server's
 	 * writer does not serialize a payload for it. */
-	if (sc1 & (1u << 7)) MSG_ReadByte (); /* bluemana */
-	if (sc1 & (1u << 8)) MSG_ReadByte (); /* greenmana */
-	if (sc1 & (1u << 9)) MSG_ReadLong (); /* experience */
-	if (sc1 & (1u << 10)) MSG_ReadByte (); /* cnt_torch */
-	if (sc1 & (1u << 11)) MSG_ReadByte (); /* cnt_h_boost */
-	if (sc1 & (1u << 12)) MSG_ReadByte (); /* cnt_sh_boost */
-	if (sc1 & (1u << 13)) MSG_ReadByte (); /* cnt_mana_boost */
-	if (sc1 & (1u << 14)) MSG_ReadByte (); /* cnt_teleport */
-	if (sc1 & (1u << 15)) MSG_ReadByte (); /* cnt_tome */
-	if (sc1 & (1u << 16)) MSG_ReadByte (); /* cnt_summon */
-	if (sc1 & (1u << 17)) MSG_ReadByte (); /* cnt_invisibility */
-	if (sc1 & (1u << 18)) MSG_ReadByte (); /* cnt_glyph */
-	if (sc1 & (1u << 19)) MSG_ReadByte (); /* cnt_haste */
-	if (sc1 & (1u << 20)) MSG_ReadByte (); /* cnt_blast */
-	if (sc1 & (1u << 21)) MSG_ReadByte (); /* cnt_polymorph */
-	if (sc1 & (1u << 22)) MSG_ReadByte (); /* cnt_flight */
-	if (sc1 & (1u << 23)) MSG_ReadByte (); /* cnt_cubeofforce */
-	if (sc1 & (1u << 24)) MSG_ReadByte (); /* cnt_invincibility */
-	if (sc1 & (1u << 25)) MSG_ReadByte (); /* artifact_active */
-	if (sc1 & (1u << 26)) MSG_ReadByte (); /* artifact_low */
-	if (sc1 & (1u << 27)) hwcl_local_movetype = MSG_ReadByte ();
-	if (sc1 & (1u << 28)) MSG_ReadByte (); /* cameramode */
-	if (sc1 & (1u << 29)) hwcl_local_hasted = MSG_ReadFloat ();
-	if (sc1 & (1u << 30)) MSG_ReadByte (); /* inventory */
-	if (sc1 & (1u << 31)) MSG_ReadByte (); /* rings_active */
+	if (sc1 & (1u << 7)) cl.v.bluemana = MSG_ReadByte ();
+	if (sc1 & (1u << 8)) cl.v.greenmana = MSG_ReadByte ();
+	if (sc1 & (1u << 9)) cl.v.experience = MSG_ReadLong ();
+	if (sc1 & (1u << 10)) cl.v.cnt_torch = MSG_ReadByte ();
+	if (sc1 & (1u << 11)) cl.v.cnt_h_boost = MSG_ReadByte ();
+	if (sc1 & (1u << 12)) cl.v.cnt_sh_boost = MSG_ReadByte ();
+	if (sc1 & (1u << 13)) cl.v.cnt_mana_boost = MSG_ReadByte ();
+	if (sc1 & (1u << 14)) cl.v.cnt_teleport = MSG_ReadByte ();
+	if (sc1 & (1u << 15)) cl.v.cnt_tome = MSG_ReadByte ();
+	if (sc1 & (1u << 16)) cl.v.cnt_summon = MSG_ReadByte ();
+	if (sc1 & (1u << 17)) cl.v.cnt_invisibility = MSG_ReadByte ();
+	if (sc1 & (1u << 18)) cl.v.cnt_glyph = MSG_ReadByte ();
+	if (sc1 & (1u << 19)) cl.v.cnt_haste = MSG_ReadByte ();
+	if (sc1 & (1u << 20)) cl.v.cnt_blast = MSG_ReadByte ();
+	if (sc1 & (1u << 21)) cl.v.cnt_polymorph = MSG_ReadByte ();
+	if (sc1 & (1u << 22)) cl.v.cnt_flight = MSG_ReadByte ();
+	if (sc1 & (1u << 23)) cl.v.cnt_cubeofforce = MSG_ReadByte ();
+	if (sc1 & (1u << 24)) cl.v.cnt_invincibility = MSG_ReadByte ();
+	if (sc1 & (1u << 25)) cl.v.artifact_active = MSG_ReadByte ();
+	if (sc1 & (1u << 26)) cl.v.artifact_low = MSG_ReadByte ();
+	if (sc1 & (1u << 27)) cl.v.movetype = hwcl_local_movetype = MSG_ReadByte ();
+	if (sc1 & (1u << 28)) cl.v.cameramode = MSG_ReadByte ();
+	if (sc1 & (1u << 29)) cl.v.hasted = hwcl_local_hasted = MSG_ReadFloat ();
+	if (sc1 & (1u << 30)) cl.v.inventory = MSG_ReadByte ();
+	if (sc1 & (1u << 31)) cl.v.rings_active = MSG_ReadByte ();
 
-	if (sc2 & (1u << 0)) MSG_ReadByte (); /* rings_low */
-	if (sc2 & (1u << 1)) MSG_ReadByte (); /* armor_amulet */
-	if (sc2 & (1u << 2)) MSG_ReadByte (); /* armor_bracer */
-	if (sc2 & (1u << 3)) MSG_ReadByte (); /* armor_breastplate */
-	if (sc2 & (1u << 4)) MSG_ReadByte (); /* armor_helmet */
-	if (sc2 & (1u << 5)) MSG_ReadByte (); /* ring_flight */
-	if (sc2 & (1u << 6)) MSG_ReadByte (); /* ring_water */
-	if (sc2 & (1u << 7)) MSG_ReadByte (); /* ring_turning */
-	if (sc2 & (1u << 8)) MSG_ReadByte (); /* ring_regeneration */
+	if (sc2 & (1u << 0)) cl.v.rings_low = MSG_ReadByte ();
+	if (sc2 & (1u << 1)) cl.v.armor_amulet = MSG_ReadByte ();
+	if (sc2 & (1u << 2)) cl.v.armor_bracer = MSG_ReadByte ();
+	if (sc2 & (1u << 3)) cl.v.armor_breastplate = MSG_ReadByte ();
+	if (sc2 & (1u << 4)) cl.v.armor_helmet = MSG_ReadByte ();
+	if (sc2 & (1u << 5)) cl.v.ring_flight = MSG_ReadByte ();
+	if (sc2 & (1u << 6)) cl.v.ring_water = MSG_ReadByte ();
+	if (sc2 & (1u << 7)) cl.v.ring_turning = MSG_ReadByte ();
+	if (sc2 & (1u << 8)) cl.v.ring_regeneration = MSG_ReadByte ();
 	/* Bits 9 and 10 are declared but not serialized by this server. */
 	if (sc2 & (1u << 11)) MSG_ReadString (); /* puzzle_inv1 */
 	if (sc2 & (1u << 12)) MSG_ReadString (); /* puzzle_inv2 */
@@ -1441,9 +1450,11 @@ static void HWCL_ParseInventoryUpdate (void)
 	if (sc2 & (1u << 16)) MSG_ReadString (); /* puzzle_inv6 */
 	if (sc2 & (1u << 17)) MSG_ReadString (); /* puzzle_inv7 */
 	if (sc2 & (1u << 18)) MSG_ReadString (); /* puzzle_inv8 */
-	if (sc2 & (1u << 19)) MSG_ReadShort (); /* max_health */
-	if (sc2 & (1u << 20)) MSG_ReadByte (); /* max_mana */
-	if (sc2 & (1u << 21)) MSG_ReadFloat (); /* flags */
+	if (sc2 & (1u << 19)) cl.v.max_health = MSG_ReadShort ();
+	if (sc2 & (1u << 20)) cl.v.max_mana = MSG_ReadByte ();
+	if (sc2 & (1u << 21)) cl.v.flags = MSG_ReadFloat ();
+	Sbar_Changed ();
+	SB_InvChanged ();
 }
 
 static void HWCL_ParsePlayerInfo (void)
@@ -1841,8 +1852,11 @@ static void HWCL_ParseServerMessage (void)
 					/* Skin download/translation is not wired up yet, but it must
 					 * not hold the transport handshake hostage. */
 					HWCL_StringCmd (va ("begin %d", hwcl_servercount));
+					if (!cl.worldmodel)
+						Host_Error ("HexenWorld signon without a world map");
 					cls.signon = SIGNONS;
-					Con_Printf ("HexenWorld signon complete; awaiting state adapter.\n");
+					SCR_EndLoadingPlaque ();
+					Con_Printf ("HexenWorld signon complete: %s.\n", cl.mapname);
 				}
 				else if (!q_strcasecmp (text, "changing\n"))
 				{
@@ -1956,6 +1970,8 @@ qboolean HWCL_Connect (const char *host)
 	CL_ClearState ();
 	cls.state = ca_connected;
 	hwcl_state = hwcl_connecting;
+	cls.demonum = -1;
+	hwcl_connect_started = realtime;
 	HWCL_SendConnectPacket ();
 	return true;
 }
@@ -2177,7 +2193,13 @@ void HWCL_Disconnect (void)
 	 * what sends clc_disconnect, closes the qsocket, shuts down a listen
 	 * server and removes the .gip files. */
 	if (hwcl_state != hwcl_disconnected)
+	{
 		cls.state = ca_disconnected;
+		S_StopAllSounds (true);
+		cl.worldmodel = NULL;
+		FS_HWRestore ();
+		SCR_EndLoadingPlaque ();
+	}
 	hwcl_state = hwcl_disconnected;
 	hwcl_received_packet = false;
 }
@@ -2186,6 +2208,9 @@ static void HWCL_ConnectionlessPacket (void)
 {
 	int command;
 
+	/* Do not accept an unsolicited handshake/print from another endpoint. */
+	if (!HWNET_CompareAdr (&hw_net_from, &hwcl_server))
+		return;
 	MSG_BeginReadingFrom (&hw_net_message);
 	MSG_ReadLong (); /* connectionless -1 marker */
 	command = MSG_ReadByte ();
@@ -2200,6 +2225,7 @@ static void HWCL_ConnectionlessPacket (void)
 		MSG_WriteString (&hwcl_netchan.message, "new");
 		HWNetchan_Transmit (&hwcl_netchan, 0, NULL);
 		hwcl_state = hwcl_connected;
+		hwcl_last_received = realtime;
 		Con_Printf ("HexenWorld connection accepted.\n");
 		/* Recorded only once a server has answered, so a mistyped or dead
 		 * address never reaches the menu's list. */
@@ -2223,6 +2249,12 @@ void HWCL_Frame (void)
 	if (!hwcl_net_initialized || hwcl_state == hwcl_disconnected)
 		return;
 
+	if (hwcl_state == hwcl_connecting &&
+	    realtime - hwcl_connect_started > HWCL_CONNECT_TIMEOUT)
+		Host_Error ("No HexenWorld response after 15 seconds; check server address, port and firewall");
+	if (hwcl_state == hwcl_connected &&
+	    realtime - hwcl_last_received > Cvar_VariableValue ("net_messagetimeout"))
+		Host_Error ("HexenWorld server connection timed out");
 	if (hwcl_state == hwcl_connecting && realtime - hwcl_connect_time > 5.0)
 		HWCL_SendConnectPacket ();
 
@@ -2242,6 +2274,7 @@ void HWCL_Frame (void)
 		if (!HWNetchan_Process (&hwcl_netchan))
 			continue;
 
+		hwcl_last_received = realtime;
 		if (!hwcl_received_packet)
 		{
 			Con_Printf ("HexenWorld netchan established (%d payload bytes).\n",

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -237,6 +237,10 @@ Host should be either "local" or a net address to be passed on
 */
 void CL_EstablishConnection (const char *host)
 {
+#if defined(H2W_INTEGRATED)
+	qboolean auto_protocol = true;
+	qboolean return_onerror;
+#endif
 	if (cls.state == ca_dedicated)
 		return;
 
@@ -246,16 +250,39 @@ void CL_EstablishConnection (const char *host)
 	CL_Disconnect ();
 
 #if defined(H2W_INTEGRATED)
-	/* The URI makes protocol selection explicit; ordinary host names retain
-	 * Hexen II's qsocket handshake. */
+	/* Explicit schemes bypass detection. Plain addresses try the bounded H2
+	 * handshake first, then HW only if H2 did not answer (not if rejected). */
 	if (!q_strncasecmp(host, "hw://", 5))
 	{
-		HWCL_Connect (host + 5);
+		if (!HWCL_Connect (host + 5))
+			Host_Error ("Invalid HexenWorld server address");
 		return;
 	}
+	if (!q_strncasecmp(host, "h2://", 5))
+	{
+		host += 5;
+		auto_protocol = false;
+	}
+	if (!*host || !q_strcasecmp(host, "local"))
+		auto_protocol = false;
+	/* A failed H2 probe must not return to the menu while HW is joining. */
+	return_onerror = m_return_onerror;
+	if (auto_protocol)
+		m_return_onerror = false;
 #endif
 
 	cls.netcon = NET_Connect (host);
+#if defined(H2W_INTEGRATED)
+	if (!cls.netcon && auto_protocol && net_connect_no_response)
+	{
+		Con_Printf ("No Hexen II response; trying HexenWorld...\n");
+		if (!HWCL_Connect (host))
+			Host_Error ("Invalid multiplayer server address");
+		return;
+	}
+	if (!cls.netcon)
+		m_return_onerror = return_onerror;
+#endif
 	if (!cls.netcon)
 		Host_Error ("%s: connect failed", __thisfunc__);
 	Con_DPrintf ("%s: connected to %s\n", __thisfunc__, host);

--- a/engine/hexen2/menu.c
+++ b/engine/hexen2/menu.c
@@ -8837,7 +8837,7 @@ static int M_HWServers_RowY (int row)
 	return HWSERVERS_LIST_Y + (row - HWSERVERS_FIRST) * 8;
 }
 
-/* Trim the address and drop a typed hw:// -- the join adds the scheme.  False
+/* Trim the address and drop a typed hw:// -- plain joins autodetect.  False
  * for an empty address, one too long for the connect command (which would cut
  * it short and connect somewhere else), or one with a character that would
  * break out of its quoted argument.  dst holds HW_ADDRESS_MAX + 1. */
@@ -8905,7 +8905,7 @@ static qboolean M_HW_Join (const char *address)
 		return false;
 	Key_SetDest (key_game);
 	m_state = m_none;
-	Cbuf_AddText (va ("connect \"hw://%s\"\n", addr));
+	Cbuf_AddText (va ("connect \"%s\"\n", addr));
 	return true;
 }
 

--- a/engine/hexen2/menu.h
+++ b/engine/hexen2/menu.h
@@ -59,6 +59,7 @@ enum m_state_e
 
 extern	enum m_state_e	m_state;
 extern	enum m_state_e	m_return_state;
+extern qboolean m_return_onerror;
 
 /* menus */
 void M_Init (void);

--- a/engine/hexen2/net.h
+++ b/engine/hexen2/net.h
@@ -46,6 +46,7 @@ struct qsocket_s	*NET_CheckNewConnections (void);
 // returns a new connection number if there is one pending, else -1
 
 struct qsocket_s	*NET_Connect (const char *host);
+extern qboolean net_connect_no_response; /* allows HW fallback, never on H2 rejection */
 // called by client to connect to a host.  Returns -1 if not able to
 
 double NET_QSocketGetTime (const struct qsocket_s *sock);

--- a/engine/hexen2/net_dgrm.c
+++ b/engine/hexen2/net_dgrm.c
@@ -1299,6 +1299,7 @@ static qsocket_t *_Datagram_Connect (const char *host)
 
 	if (ret == 0)
 	{
+		net_connect_no_response = true;
 		reason = "No Response";
 		Con_Printf("%s\n", reason);
 		strcpy(m_return_reason, reason);
@@ -1313,6 +1314,7 @@ static qsocket_t *_Datagram_Connect (const char *host)
 		goto ErrorReturn;
 	}
 
+	net_connect_no_response = false;
 	ret = MSG_ReadByte();
 	if (ret == CCREP_REJECT)
 	{

--- a/engine/hexen2/net_main.c
+++ b/engine/hexen2/net_main.c
@@ -430,12 +430,15 @@ NET_Connect
 int hostCacheCount = 0;
 hostcache_t hostcache[HOSTCACHESIZE];
 
+qboolean net_connect_no_response;
+
 qsocket_t *NET_Connect (const char *host)
 {
 	qsocket_t		*ret;
 	int				n;
 
 	SetNetTime();
+	net_connect_no_response = false;
 
 	if (host && *host == 0)
 		host = NULL;

--- a/scripts/hw-smoke.sh
+++ b/scripts/hw-smoke.sh
@@ -6,14 +6,19 @@
 # the same ground the old client network tests did, without a display:
 #
 #   1. hwsv boots, mounts hw/ on top of data1, spawns a map.
-#   2. Two GL clients connect (each on its own -hwport), sign on, and mount
-#      the server's gamedir.  Both must reach "signon complete" with zero
-#      unknown/malformed protocol messages.
+#   2. Two GL clients connect by plain address -- no hw:// scheme -- so the
+#      automatic H2-then-HW negotiation is what picks the protocol (issue #50).
+#      Each signs on, mounts the server's gamedir, and renders the world.
+#      Both must reach "signon complete" with zero unknown/malformed protocol
+#      messages and with the loading plaque dismissed.
 #   3. A server broadcast is delivered to both (say smoke-<token>).
 #   4. A live map change is issued from the server console; both clients see
 #      "Changing map..." / "reconnecting..." and complete a SECOND signon
 #      without aborting the reader, and the static-entity list does not
 #      overflow ("Too many HexenWorld static entities").
+#   5. When Siege is installed, a Siege client renders successfully, while a
+#      client with data1+hw but no Siege map aborts before signon with an
+#      actionable maps/siege.bsp error.
 #
 # Requires:
 #   - Hexen II data1 (pak0/pak1) and a HexenWorld gamedir (hw/pak4.pak,
@@ -72,13 +77,18 @@ ALOG="$WORK/client-a.log"
 BLOG="$WORK/client-b.log"
 FIFO="$WORK/console"
 FAILURES=0
+# Initialised before the trap: cleanup runs under `set -u`, so an early exit
+# (Xvfb refused to start, an unusable basedir) must not trip over an unset PID.
+SRV_PID=""; CA_PID=""; CB_PID=""; CP_PID=""; SIEGE_PID=""; XV_PID=""
 
 cleanup() {
 	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
 	[ -n "$CA_PID" ] && kill "$CA_PID" 2>/dev/null
 	[ -n "$CB_PID" ] && kill "$CB_PID" 2>/dev/null
+	[ -n "$CP_PID" ] && kill "$CP_PID" 2>/dev/null
+	[ -n "$SIEGE_PID" ] && kill "$SIEGE_PID" 2>/dev/null
 	[ -n "$XV_PID" ] && kill "$XV_PID" 2>/dev/null
-	exec 3>&-
+	exec 3>&- 4>&-
 	rm -rf "$WORK"
 }
 trap cleanup EXIT
@@ -137,24 +147,31 @@ SRV_PID=$!
 wait_for "$SLOG" 'Building PHS' || { tail -40 "$SLOG"; fail "server did not reach map spawn"; }
 
 # --- client A ---
-DISPLAY="$DISPNUM" stdbuf -oL -eL "$CLIENT" -basedir "$BASEDIR" -nolan -hwport 27001 +developer 1 \
-	+connect "hw://127.0.0.1" > "$ALOG" 2>&1 &
+DISPLAY="$DISPNUM" stdbuf -oL -eL "$CLIENT" -basedir "$BASEDIR" -hwport 27001 +developer 1 \
+	+connect "127.0.0.1" > "$ALOG" 2>&1 &
 CA_PID=$!
 
 wait_for "$ALOG" 'HexenWorld signon complete' || { fail "client A did not complete signon"; }
 wait_for "$ALOG" 'HexenWorld server set the gamedir to hw' || fail "client A did not mount the hw gamedir"
 wait_for "$ALOG" 'player 0 spawned' || fail "client A never saw its own spawn"
+# A plain address must reach HW by negotiation, never by the hw:// override.
+wait_for "$ALOG" 'No Hexen II response; trying HexenWorld' || fail "client A did not autodetect HexenWorld"
+# Signon has to dismiss the loading plaque and actually draw, or the player sits
+# behind a frozen loading screen (the reported issue #50 failure).
+wait_for "$ALOG" 'First world draw completed' || fail "client A never rendered the world"
+grep -q 'HexenWorld missing world map' "$ALOG" && fail "client A reported a missing world map"
 no_badness "$ALOG" || fail "client A hit a protocol abort"
 
 # --- client B ---
 sleep 2
-DISPLAY="$DISPNUM" stdbuf -oL -eL "$CLIENT" -basedir "$BASEDIR" -nolan -hwport 27002 +developer 1 \
+DISPLAY="$DISPNUM" stdbuf -oL -eL "$CLIENT" -basedir "$BASEDIR" -hwport 27002 +developer 1 \
 	+connect "hw://127.0.0.1" > "$BLOG" 2>&1 &
 CB_PID=$!
 
 wait_for "$BLOG" 'HexenWorld protocol 100.*player 1' || { fail "server did not give client B player slot 1"; }
 wait_for "$BLOG" 'HexenWorld signon complete' || fail "client B did not complete signon"
 wait_for "$BLOG" 'player 1 spawned' || fail "client B never saw its own spawn"
+wait_for "$BLOG" 'First world draw completed' || fail "client B never rendered the world"
 no_badness "$BLOG" || fail "client B hit a protocol abort"
 
 # --- broadcast to both ---
@@ -189,6 +206,58 @@ say "static records parsed: A=$((nsa + 0)) B=$((nsb + 0))"
 no_badness "$ALOG" || fail "client A aborted during/after the map change"
 no_badness "$BLOG" || fail "client B aborted during/after the map change"
 
+# --- optional Siege leg (issue #50) ---
+# Siege is an HW mod, not a third protocol: the server advertises gamedir
+# "siege" and the client must layer siege/ above the hw/ base.  Only runs when
+# the mod is actually installed, since the base hw install has no siege.bsp.
+if [ -d "$BASEDIR/siege" ] && [ -f "$BASEDIR/siege/maps/siege.bsp" ]; then
+	CLOG="$WORK/client-siege.log"
+	SFIFO="$WORK/console-siege"
+	mkfifo "$SFIFO"
+	exec 4<>"$SFIFO"
+	script -qefc "$SERVER -basedir $BASEDIR -userdir $WORK/usr-siege -game siege -port 27003 +map siege" \
+		"$WORK/server-siege.log" < "$SFIFO" >/dev/null 2>&1 &
+	SIEGE_PID=$!
+
+	wait_for "$WORK/server-siege.log" 'Building PHS' || fail "siege server did not spawn its map"
+
+	DISPLAY="$DISPNUM" stdbuf -oL -eL "$CLIENT" -basedir "$BASEDIR" -hwport 27004 +developer 1 \
+		+connect "127.0.0.1:27003" > "$CLOG" 2>&1 &
+	CP_PID=$!
+
+	wait_for "$CLOG" 'HexenWorld server set the gamedir to siege' 120 || fail "siege client did not mount the siege gamedir"
+	wait_for "$CLOG" 'HexenWorld signon complete: siege' 180 || fail "siege client did not complete signon"
+	wait_for "$CLOG" 'First world draw completed' 120 || fail "siege client never rendered the world"
+	grep -q 'HexenWorld missing world map' "$CLOG" && fail "siege client reported a missing world map"
+	no_badness "$CLOG" || fail "siege client hit a protocol abort"
+
+	kill "$CP_PID" 2>/dev/null; wait "$CP_PID" 2>/dev/null; CP_PID=""
+
+	# The same server against a client install with data1+hw but no Siege map
+	# must abort before signon with the exact missing path. Symlinks avoid
+	# copying proprietary data into the test workdir.
+	MISSING_BASE="$WORK/missing-base"
+	MLOG="$WORK/client-missing-siege.log"
+	mkdir -p "$MISSING_BASE/siege"
+	ln -s "$BASEDIR/data1" "$MISSING_BASE/data1"
+	ln -s "$BASEDIR/hw" "$MISSING_BASE/hw"
+	DISPLAY="$DISPNUM" stdbuf -oL -eL "$CLIENT" -basedir "$MISSING_BASE" -hwport 27005 +developer 1 \
+		+connect "127.0.0.1:27003" > "$MLOG" 2>&1 &
+	CP_PID=$!
+	wait_for "$MLOG" 'Host_Error: HexenWorld missing world map: maps/siege\.bsp' 180 || \
+		fail "missing-Siege client did not report the required world map"
+	grep -q 'HexenWorld signon complete' "$MLOG" && fail "missing-Siege client completed signon"
+	wait_for "$MLOG" 'Install hw/pak4\.pak.*siege mod assets' 10 || \
+		fail "missing-Siege error was not actionable"
+	kill "$CP_PID" 2>/dev/null; wait "$CP_PID" 2>/dev/null; CP_PID=""
+
+	printf 'quit\n' >&4
+	sleep 2
+	wait "$SIEGE_PID" 2>/dev/null; SIEGE_PID=""
+else
+	say "siege: skipped ($BASEDIR/siege/maps/siege.bsp not installed)"
+fi
+
 # --- shut down ---
 printf 'quit\n' >&3
 sleep 2
@@ -198,7 +267,7 @@ CA_PID=""; CB_PID=""
 wait "$SRV_PID" 2>/dev/null; SRV_PID=""
 
 if [ "$FAILURES" -eq 0 ]; then
-	say "PASS: HexenWorld headless smoke (2 clients, broadcast, map change)."
+	say "PASS: HexenWorld smoke (autodetect, 2 clients, map change, optional Siege/content checks)."
 	exit 0
 fi
 say "FAILED: $FAILURES assertion(s).  Logs: $WORK (removed on exit)."

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,8 +11,9 @@ Editing either one rebuilds `.#gamecode`. If you add a third build-time tool,
 add it to that allowlist and to this paragraph — or put it in `scripts/`
 instead, which is where things that run during a build belong.
 
-Two more are CI gates rather than build inputs: `menu_soft_parity.py` and
-`ironwail_scorecard.py --check` both run in `.github/workflows/lint.yml`.
+Three more are CI gates rather than build inputs: `menu_soft_parity.py`,
+`test_multiplayer_join.py`, and `ironwail_scorecard.py --check` all run in
+`.github/workflows/lint.yml`.
 
 These are plain scripts, run directly. The Python ones need only stock
 `python3` (no third-party modules) except `pak_extract.py`, which needs Pillow.
@@ -27,6 +28,7 @@ These are plain scripts, run directly. The Python ones need only stock
 | `pak_extract.py` | extract textures/skins/GFX from a PAK to PNG |
 | `upscale-pak.sh` | extract and AI-upscale PAK textures to TGA overrides |
 | `progs_crc.py` | print the two CRCs `PR_ClassifyGamecode()` identifies a `progs.dat` by |
+| `test_multiplayer_join.py` | compile extracted production join/filesystem functions and test protocol fallback, gamedir validation, HW/Siege precedence, and restoration |
 
 ---
 

--- a/tools/test_multiplayer_join.py
+++ b/tools/test_multiplayer_join.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Data-free regression tests for the production join and HW search-path code.
+
+Extract the actual C functions, stub their engine dependencies, and compile/run
+with the host C compiler. No renderer, proprietary paks, or running server needed.
+Runtime gameplay coverage remains in the multiplayer smoke tests.
+"""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def function(path, signature):
+    text = (ROOT / path).read_text()
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 1
+    end = brace + 1
+    while depth:
+        depth += (text[end] == "{") - (text[end] == "}")
+        end += 1
+    return text[start:end]
+
+
+PRELUDE = r'''
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#define H2W_INTEGRATED 1
+#define MAX_QPATH 64
+#define MAX_OSPATH 256
+#define __thisfunc__ __func__
+typedef int qboolean;
+#define true 1
+#define false 0
+#define q_strcasecmp strcasecmp
+#define q_strncasecmp strncasecmp
+static void q_strlcpy(char *d, const char *s, size_t n) { snprintf(d,n,"%s",s); }
+'''
+
+FS_STUBS = r'''
+typedef struct path_s { struct path_s *next; char name[64]; } searchpath_t;
+static searchpath_t base = {NULL,"data1"}, local = {&base,"localmod"};
+static searchpath_t *fs_searchpaths = &local, *fs_base_searchpaths = &base;
+static char fs_gamedir_nopath[64] = "localmod";
+static char fs_gamedir[256] = "/base/localmod", fs_userdir[256] = "/user/localmod";
+static unsigned int gameflags = 123;
+static int added, freed;
+static void Cache_Flush(void) {}
+static void FS_UnwindSearchpaths(searchpath_t *mark, qboolean verbose) {
+    (void)verbose;
+    while (fs_searchpaths != mark) {
+        assert(fs_searchpaths != &local && fs_searchpaths != &base);
+        searchpath_t *next = fs_searchpaths->next;
+        free(fs_searchpaths); freed++; fs_searchpaths = next;
+    }
+}
+static void FS_AddGameDirectory(const char *dir, qboolean base_fs) {
+    (void)base_fs;
+    searchpath_t *p = calloc(1,sizeof(*p)); assert(p);
+    q_strlcpy(p->name,dir,sizeof(p->name)); p->next=fs_searchpaths; fs_searchpaths=p;
+    q_strlcpy(fs_gamedir_nopath,dir,sizeof(fs_gamedir_nopath));
+    snprintf(fs_gamedir,sizeof(fs_gamedir),"/base/%s",dir);
+    snprintf(fs_userdir,sizeof(fs_userdir),"/user/%s",dir);
+    gameflags |= 256; added++;
+}
+'''
+
+FS_TESTS = r'''
+int main(void) {
+    const char *bad[] = {"", ".", "..", "../siege", "a/b", "a\\b", "C:siege",
+        "data1", "PORTALS", "siege\nquit", "siege;quit", "a\"b", "a b", "a..b"};
+    for (size_t i=0;i<sizeof(bad)/sizeof(bad[0]);i++) {
+        assert(!FS_HWGamedir(bad[i])); assert(fs_searchpaths == &local);
+    }
+    char longdir[80]; memset(longdir,'a',79); longdir[79]=0;
+    assert(!FS_HWGamedir(longdir));
+    assert(FS_HWGamedir("siege"));
+    assert(!strcmp(fs_searchpaths->name,"siege"));
+    assert(!strcmp(fs_searchpaths->next->name,"hw"));
+    assert(fs_searchpaths->next->next == &base); /* local mod excluded */
+    assert(!strcmp(fs_userdir,"/user/siege"));
+    searchpath_t *unchanged = fs_searchpaths;
+    assert(!FS_HWGamedir("../bad")); assert(fs_searchpaths == unchanged);
+    assert(FS_HWGamedir("hw")); /* map/server switch removes previous mod */
+    assert(!strcmp(fs_searchpaths->name,"hw")); assert(fs_searchpaths->next == &base);
+    assert(FS_HWGamedir("siege")); /* reconnect does not accumulate paths */
+    assert(FS_HWGamedir("siege"));
+    FS_HWRestore();
+    assert(fs_searchpaths == &local && local.next == &base);
+    assert(!strcmp(fs_gamedir_nopath,"localmod"));
+    assert(!strcmp(fs_gamedir,"/base/localmod"));
+    assert(!strcmp(fs_userdir,"/user/localmod")); assert(gameflags == 123);
+    FS_HWRestore(); assert(added == freed); /* idempotent disconnect */
+    puts("PASS: safe HW/mod layering, invalid gamedirs, repeated switches and exact restoration");
+}
+'''
+
+JOIN_STUBS = r'''
+enum { ca_disconnected, ca_connected, ca_dedicated, clc_nop };
+static struct { int state,demoplayback,demonum,signon,message; void *netcon; } cls;
+static qboolean net_connect_no_response, m_return_onerror;
+static int net_calls, hw_calls, net_result, hw_result=1, disconnects;
+static char last_net[128], last_hw[128];
+static jmp_buf abort_join;
+static void CL_Disconnect(void) { disconnects++; }
+static void *NET_Connect(const char *h) {
+    net_calls++; q_strlcpy(last_net,h,sizeof(last_net));
+    return net_result ? &cls : NULL;
+}
+static qboolean HWCL_Connect(const char *h) {
+    hw_calls++; q_strlcpy(last_hw,h,sizeof(last_hw)); return hw_result;
+}
+static void Host_Error(const char *fmt,...) { (void)fmt; longjmp(abort_join,1); }
+static void Con_Printf(const char *fmt,...) { (void)fmt; }
+#define Con_DPrintf Con_Printf
+static void MSG_WriteByte(int *m,int b) { *m=b; }
+static void reset(void) {
+    memset(&cls,0,sizeof(cls)); net_calls=hw_calls=disconnects=0;
+    net_result=0; hw_result=1; net_connect_no_response=0; m_return_onerror=1;
+}
+'''
+
+JOIN_TESTS = r'''
+int main(void) {
+    reset(); net_result=1; CL_EstablishConnection("host:26900");
+    assert(net_calls==1 && hw_calls==0 && cls.state==ca_connected);
+    reset(); net_connect_no_response=1; CL_EstablishConnection("host:26950");
+    assert(net_calls==1 && hw_calls==1 && !strcmp(last_hw,"host:26950"));
+    assert(!m_return_onerror);
+    reset(); CL_EstablishConnection("hw://host:26950");
+    assert(net_calls==0 && hw_calls==1 && !strcmp(last_hw,"host:26950"));
+    reset(); net_result=1; CL_EstablishConnection("h2://host:26900");
+    assert(net_calls==1 && hw_calls==0 && !strcmp(last_net,"host:26900"));
+    reset(); /* an H2 rejection/error must not try another protocol */
+    if (!setjmp(abort_join)) { CL_EstablishConnection("host"); assert(0); }
+    assert(net_calls==1 && hw_calls==0 && m_return_onerror);
+    reset(); net_connect_no_response=1;
+    if (!setjmp(abort_join)) { CL_EstablishConnection("h2://host"); assert(0); }
+    assert(hw_calls==0);
+    reset(); net_connect_no_response=1;
+    if (!setjmp(abort_join)) { CL_EstablishConnection("local"); assert(0); }
+    assert(hw_calls==0);
+    reset(); hw_result=0;
+    if (!setjmp(abort_join)) { CL_EstablishConnection("hw://bad"); assert(0); }
+    assert(net_calls==0);
+    puts("PASS: automatic H2/HW selection, explicit overrides, local connection and rejection handling");
+}
+'''
+
+
+def main():
+    fs = (ROOT / "engine/h2shared/quakefs.c").read_text()
+    start = fs.index("static searchpath_t *fs_hw_saved_paths;")
+    end = fs.index("\n#endif", start)
+    cases = {
+        "paths": PRELUDE + FS_STUBS + fs[start:end] + FS_TESTS,
+        "join": PRELUDE + JOIN_STUBS + function(
+            "engine/hexen2/cl_main.c", "void CL_EstablishConnection (const char *host)"
+        ) + JOIN_TESTS,
+    }
+    with tempfile.TemporaryDirectory(prefix="multiplayer-join-") as tmp:
+        for name, source in cases.items():
+            cfile = Path(tmp) / (name + ".c")
+            binary = Path(tmp) / name
+            cfile.write_text(source)
+            subprocess.run([os.environ.get("CC", "cc"), "-std=c99", "-Wall", "-Wextra",
+                            str(cfile), "-o", str(binary)], check=True)
+            subprocess.run([str(binary)], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #50.

## Summary
- try bounded Hexen II negotiation first for plain joins, then HexenWorld only when H2 gives no response; retain `h2://` / `hw://` overrides
- validate server gamedirs and mount temporary `siege > hw > retail` search paths, restoring the local game on disconnect/switch
- fail signon with actionable missing-content errors and always dismiss loading on completion/error/disconnect
- complete the HW state adapter fields needed for a correct camera, HUD, movement, and weapon frame
- document the complete Siege archive requirement and add data-free CI plus expanded live smoke coverage

## Verification
- `nix build .#default --out-link /tmp/issue50-default`
- `nix build .#h2ded --out-link /tmp/issue50-h2ded`
- `nix build .#hwsv --out-link /tmp/issue50-hwsv`
- `nix develop --command python3 tools/test_multiplayer_join.py`
- `scripts/hw-smoke.sh` with local retail/HW/Siege fixtures: two clients, plain-address HW autodetect, broadcast, live map change, Siege render, and missing-Siege abort all passed
- latest Nix binaries rendered H2 `demo1`, HW `hwdm1`, and Siege `siege`; movement changed view positions in all three; own players/entities spawned
- Siege sound exercised through SDL's disk driver: no sound-load failures and nonzero PCM output (peak 21178)
- HW → disconnect → Siege → HW passed with no stale Siege path; dead endpoint produced the actionable HW timeout after 24 seconds total negotiation

`nix build .#wasm` reached compilation but the Emscripten port attempted an in-sandbox network fetch and failed DNS; this was an external dependency-fetch failure, not a compiler diagnostic from these changes.
