### PR TITLE
Multiplayer: require H2 signon before committing protocol

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -99,9 +99,10 @@ To launch a mod with portals data included: `glhexen2 -mod <modname>`
 ## Multiplayer
 
 The multiplayer menu and the ordinary `connect` command automatically try the
-Hexen II protocol first, then try HexenWorld when the Hexen II server does not
-answer. Use `h2://address` or `hw://address` to force a protocol when needed;
-this fallback is bounded and an H2 rejection is not silently retried as HW.
+Hexen II protocol first, then try HexenWorld when the Hexen II endpoint does not
+answer or accepts the control request but sends no H2 signon data. Use
+`h2://address` or `hw://address` to force a protocol when needed; this fallback
+is bounded and an H2 rejection is not silently retried as HW.
 
 A vanilla HexenWorld install needs the retail `data1/pak0.pak` and
 `pak1.pak`, plus `hw/pak4.pak` from the [Hammer of Thyrion HexenWorld game

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -52,6 +52,32 @@ cvar_t	cl_showunbound = {"cl_showunbound", "0", CVAR_ARCHIVE};
 
 cvar_t	cfg_unbindall = {"cfg_unbindall", "1", CVAR_ARCHIVE};
 
+#if defined(H2W_INTEGRATED)
+/* A control-packet accept is not enough to identify H2: an HW endpoint (or a
+ * stale listener beside it) can produce bytes that satisfy that tiny reply.
+ * Keep plain joins provisional until the first real H2 server message. */
+#define CL_AUTO_H2_CONFIRM_TIMEOUT 5.0
+static qboolean cl_auto_h2_pending;
+static double cl_auto_h2_started;
+static char cl_auto_h2_host[MAX_QPATH];
+
+static qboolean CL_AutoProtocolFallback (qboolean force)
+{
+	char host[MAX_QPATH];
+
+	if (!cl_auto_h2_pending ||
+	    (!force && realtime - cl_auto_h2_started < CL_AUTO_H2_CONFIRM_TIMEOUT))
+		return false;
+	q_strlcpy (host, cl_auto_h2_host, sizeof(host));
+	cl_auto_h2_pending = false;
+	Con_Printf ("Hexen II accepted but sent no signon data; trying HexenWorld...\n");
+	CL_Disconnect ();
+	if (!HWCL_Connect (host))
+		Host_Error ("Invalid multiplayer server address");
+	return true;
+}
+#endif
+
 /* Always-on mouselook, the name every Quake-lineage engine uses.  A config or
  * mod written for one of them says `freelook 1` and, until now, got "Unknown
  * command" and no mouselook setting at all.
@@ -171,6 +197,7 @@ This is also called on Host_Error, so it shouldn't cause any errors
 void CL_Disconnect (void)
 {
 #if defined(H2W_INTEGRATED)
+	cl_auto_h2_pending = false;
 	HWCL_Disconnect ();
 #endif
 // don't get stuck in chat mode
@@ -287,6 +314,14 @@ void CL_EstablishConnection (const char *host)
 		Host_Error ("%s: connect failed", __thisfunc__);
 	Con_DPrintf ("%s: connected to %s\n", __thisfunc__, host);
 
+#if defined(H2W_INTEGRATED)
+	if (auto_protocol)
+	{
+		q_strlcpy (cl_auto_h2_host, host, sizeof(cl_auto_h2_host));
+		cl_auto_h2_started = realtime;
+		cl_auto_h2_pending = true;
+	}
+#endif
 	cls.demonum = -1;			// not in the demo loop now
 	cls.state = ca_connected;
 	cls.signon = 0;				// need all the signon messages before playing
@@ -1375,14 +1410,34 @@ int CL_ReadFromServer (void)
 	{
 		ret = CL_GetMessage ();
 		if (ret == -1)
+		{
+#if defined(H2W_INTEGRATED)
+			/* A provisional qsocket that dies before one H2 message is no
+			 * stronger evidence than one that stays silent. */
+			if (CL_AutoProtocolFallback (true))
+				return 0;
+#endif
 			Host_Error ("%s: lost server connection", __thisfunc__);
+		}
 		if (!ret)
 			break;
 
 		cl.last_received_message = realtime;
 		CL_ParseServerMessage ();
+#if defined(H2W_INTEGRATED)
+		/* Control traffic and svc_nop do not prove the server will speak H2.
+		 * Commit only once the ordinary parser advances H2 signon. */
+		if (cls.signon > 0)
+			cl_auto_h2_pending = false;
+#endif
 	} while (ret && cls.state == ca_connected);
 
+#if defined(H2W_INTEGRATED)
+	/* Drain a signon packet already waiting in the socket before applying the
+	 * deadline. This matters after a long render/filesystem stall. */
+	if (CL_AutoProtocolFallback (false))
+		return 0;
+#endif
 	if (cl_shownet.integer)
 		Con_Printf ("\n");
 

--- a/scripts/hw-smoke.sh
+++ b/scripts/hw-smoke.sh
@@ -6,9 +6,10 @@
 # the same ground the old client network tests did, without a display:
 #
 #   1. hwsv boots, mounts hw/ on top of data1, spawns a map.
-#   2. Two GL clients connect by plain address -- no hw:// scheme -- so the
-#      automatic H2-then-HW negotiation is what picks the protocol (issue #50).
-#      Each signs on, mounts the server's gamedir, and renders the world.
+#   2. A tiny UDP fixture sends client A a syntactically valid H2 acceptance
+#      and then stays silent. The bounded post-accept timeout must still select
+#      HW; client B uses the explicit hw:// override. Each signs on, mounts the
+#      server's gamedir, and renders the world (issue #50).
 #      Both must reach "signon complete" with zero unknown/malformed protocol
 #      messages and with the loading plaque dismissed.
 #   3. A server broadcast is delivered to both (say smoke-<token>).
@@ -27,6 +28,7 @@
 #     hwsv boot smoke.
 #   - Xvfb for the GL clients; pass the store path with --xvfb if Xvfb is not
 #     on PATH, and --client / --server for the binaries.
+#   - Python 3 for the false-H2-accept UDP fixture.
 #
 # Usage:
 #   hw-smoke.sh --basedir DIR [--client BIN] [--server BIN] [--xvfb BIN]
@@ -79,7 +81,7 @@ FIFO="$WORK/console"
 FAILURES=0
 # Initialised before the trap: cleanup runs under `set -u`, so an early exit
 # (Xvfb refused to start, an unusable basedir) must not trip over an unset PID.
-SRV_PID=""; CA_PID=""; CB_PID=""; CP_PID=""; SIEGE_PID=""; XV_PID=""
+SRV_PID=""; CA_PID=""; CB_PID=""; CP_PID=""; SIEGE_PID=""; XV_PID=""; FAKE_PID=""
 
 cleanup() {
 	[ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
@@ -87,6 +89,7 @@ cleanup() {
 	[ -n "$CB_PID" ] && kill "$CB_PID" 2>/dev/null
 	[ -n "$CP_PID" ] && kill "$CP_PID" 2>/dev/null
 	[ -n "$SIEGE_PID" ] && kill "$SIEGE_PID" 2>/dev/null
+	[ -n "$FAKE_PID" ] && kill "$FAKE_PID" 2>/dev/null
 	[ -n "$XV_PID" ] && kill "$XV_PID" 2>/dev/null
 	exec 3>&- 4>&-
 	rm -rf "$WORK"
@@ -146,6 +149,25 @@ SRV_PID=$!
 
 wait_for "$SLOG" 'Building PHS' || { tail -40 "$SLOG"; fail "server did not reach map spawn"; }
 
+# A valid H2 control reply is only a provisional protocol match. Reproduce the
+# field failure by accepting on H2's default port without ever sending signon.
+cat > "$WORK/false-h2-accept.py" <<'PY'
+import socket
+import struct
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(("127.0.0.1", 26900))
+while True:
+    request, address = sock.recvfrom(8192)
+    if len(request) >= 5 and request[4] == 1:  # CCREQ_CONNECT
+        payload = bytes([0x81]) + struct.pack("<I", 26900)  # CCREP_ACCEPT
+        header = struct.pack(">I", 0x80000000 | (4 + len(payload)))
+        sock.sendto(header + payload, address)
+PY
+python3 "$WORK/false-h2-accept.py" > "$WORK/false-h2-accept.log" 2>&1 &
+FAKE_PID=$!
+sleep 1
+
 # --- client A ---
 DISPLAY="$DISPNUM" stdbuf -oL -eL "$CLIENT" -basedir "$BASEDIR" -hwport 27001 +developer 1 \
 	+connect "127.0.0.1" > "$ALOG" 2>&1 &
@@ -154,8 +176,10 @@ CA_PID=$!
 wait_for "$ALOG" 'HexenWorld signon complete' || { fail "client A did not complete signon"; }
 wait_for "$ALOG" 'HexenWorld server set the gamedir to hw' || fail "client A did not mount the hw gamedir"
 wait_for "$ALOG" 'player 0 spawned' || fail "client A never saw its own spawn"
-# A plain address must reach HW by negotiation, never by the hw:// override.
-wait_for "$ALOG" 'No Hexen II response; trying HexenWorld' || fail "client A did not autodetect HexenWorld"
+# A control-packet acceptance without real H2 traffic must remain provisional.
+wait_for "$ALOG" 'Hexen II accepted but sent no signon data; trying HexenWorld' || \
+	fail "client A committed to a false Hexen II acceptance"
+kill "$FAKE_PID" 2>/dev/null; wait "$FAKE_PID" 2>/dev/null; FAKE_PID=""
 # Signon has to dismiss the loading plaque and actually draw, or the player sits
 # behind a frozen loading screen (the reported issue #50 failure).
 wait_for "$ALOG" 'First world draw completed' || fail "client A never rendered the world"

--- a/tools/test_multiplayer_join.py
+++ b/tools/test_multiplayer_join.py
@@ -106,11 +106,19 @@ int main(void) {
 JOIN_STUBS = r'''
 enum { ca_disconnected, ca_connected, ca_dedicated, clc_nop };
 static struct { int state,demoplayback,demonum,signon,message; void *netcon; } cls;
+static struct { double last_received_message; } cl;
+static struct { int integer; } cl_shownet;
 static qboolean net_connect_no_response, m_return_onerror;
 static int net_calls, hw_calls, net_result, hw_result=1, disconnects;
 static char last_net[128], last_hw[128];
+static double realtime;
+static int reads[4], readpos, parse_signon;
+#define CL_AUTO_H2_CONFIRM_TIMEOUT 5.0
+static qboolean cl_auto_h2_pending;
+static double cl_auto_h2_started;
+static char cl_auto_h2_host[MAX_QPATH];
 static jmp_buf abort_join;
-static void CL_Disconnect(void) { disconnects++; }
+static void CL_Disconnect(void) { disconnects++; cl_auto_h2_pending=false; }
 static void *NET_Connect(const char *h) {
     net_calls++; q_strlcpy(last_net,h,sizeof(last_net));
     return net_result ? &cls : NULL;
@@ -118,13 +126,26 @@ static void *NET_Connect(const char *h) {
 static qboolean HWCL_Connect(const char *h) {
     hw_calls++; q_strlcpy(last_hw,h,sizeof(last_hw)); return hw_result;
 }
+static void HWCL_Frame(void) {}
+static qboolean HWCL_Active(void) { return false; }
+static void HWCL_ApplyState(void) {}
+static void CL_AdvanceTime(void) {}
+static int CL_GetMessage(void) { assert(readpos < 4); return reads[readpos++]; }
+static void CL_ParseServerMessage(void) { if (parse_signon) cls.signon=1; }
+static void CL_RelinkEntities(void) {}
+static void CL_UpdateEffects(void) {}
+static void CL_UpdateTEnts(void) {}
+static void CL_UpdateDevStats(void) {}
 static void Host_Error(const char *fmt,...) { (void)fmt; longjmp(abort_join,1); }
 static void Con_Printf(const char *fmt,...) { (void)fmt; }
 #define Con_DPrintf Con_Printf
 static void MSG_WriteByte(int *m,int b) { *m=b; }
 static void reset(void) {
-    memset(&cls,0,sizeof(cls)); net_calls=hw_calls=disconnects=0;
+    memset(&cls,0,sizeof(cls)); memset(&cl,0,sizeof(cl));
+    memset(reads,0,sizeof(reads)); readpos=parse_signon=0;
+    net_calls=hw_calls=disconnects=0; realtime=100; cl_shownet.integer=0;
     net_result=0; hw_result=1; net_connect_no_response=0; m_return_onerror=1;
+    cl_auto_h2_pending=false; cl_auto_h2_started=0; cl_auto_h2_host[0]=0;
 }
 '''
 
@@ -132,6 +153,15 @@ JOIN_TESTS = r'''
 int main(void) {
     reset(); net_result=1; CL_EstablishConnection("host:26900");
     assert(net_calls==1 && hw_calls==0 && cls.state==ca_connected);
+    assert(cl_auto_h2_pending && cl_auto_h2_started==realtime);
+    assert(!strcmp(cl_auto_h2_host,"host:26900"));
+    realtime += 4.9; assert(!CL_AutoProtocolFallback(false));
+    realtime += .2; assert(CL_AutoProtocolFallback(false));
+    assert(disconnects==2 && hw_calls==1 && !strcmp(last_hw,"host:26900"));
+    reset(); cl_auto_h2_pending=true; cl_auto_h2_started=realtime;
+    q_strlcpy(cl_auto_h2_host,"dropped",sizeof(cl_auto_h2_host));
+    assert(CL_AutoProtocolFallback(true)); /* provisional qsocket died early */
+    assert(hw_calls==1 && !strcmp(last_hw,"dropped"));
     reset(); net_connect_no_response=1; CL_EstablishConnection("host:26950");
     assert(net_calls==1 && hw_calls==1 && !strcmp(last_hw,"host:26950"));
     assert(!m_return_onerror);
@@ -139,6 +169,7 @@ int main(void) {
     assert(net_calls==0 && hw_calls==1 && !strcmp(last_hw,"host:26950"));
     reset(); net_result=1; CL_EstablishConnection("h2://host:26900");
     assert(net_calls==1 && hw_calls==0 && !strcmp(last_net,"host:26900"));
+    assert(!cl_auto_h2_pending); realtime += 10; assert(!CL_AutoProtocolFallback(false));
     reset(); /* an H2 rejection/error must not try another protocol */
     if (!setjmp(abort_join)) { CL_EstablishConnection("host"); assert(0); }
     assert(net_calls==1 && hw_calls==0 && m_return_onerror);
@@ -151,7 +182,19 @@ int main(void) {
     reset(); hw_result=0;
     if (!setjmp(abort_join)) { CL_EstablishConnection("hw://bad"); assert(0); }
     assert(net_calls==0);
-    puts("PASS: automatic H2/HW selection, explicit overrides, local connection and rejection handling");
+
+    reset(); cls.netcon=&cls; cls.state=ca_connected; cl_auto_h2_pending=true;
+    cl_auto_h2_started=90; q_strlcpy(cl_auto_h2_host,"queued",sizeof(cl_auto_h2_host));
+    reads[0]=1; reads[1]=0; parse_signon=1; CL_ReadFromServer();
+    assert(cls.signon==1 && !cl_auto_h2_pending && hw_calls==0 && readpos==2);
+    reset(); cls.netcon=&cls; cls.state=ca_connected; cl_auto_h2_pending=true;
+    cl_auto_h2_started=90; q_strlcpy(cl_auto_h2_host,"nop",sizeof(cl_auto_h2_host));
+    reads[0]=1; reads[1]=0; CL_ReadFromServer();
+    assert(hw_calls==1 && !strcmp(last_hw,"nop")); /* svc_nop cannot confirm H2 */
+    reset(); cls.netcon=&cls; cls.state=ca_connected; cl_auto_h2_pending=true;
+    cl_auto_h2_started=realtime; q_strlcpy(cl_auto_h2_host,"dropped",sizeof(cl_auto_h2_host));
+    reads[0]=-1; CL_ReadFromServer(); assert(hw_calls==1); /* early socket loss */
+    puts("PASS: automatic selection, overrides, rejection handling, and provisional H2 lifecycle");
 }
 '''
 
@@ -163,7 +206,11 @@ def main():
     cases = {
         "paths": PRELUDE + FS_STUBS + fs[start:end] + FS_TESTS,
         "join": PRELUDE + JOIN_STUBS + function(
+            "engine/hexen2/cl_main.c", "static qboolean CL_AutoProtocolFallback (qboolean force)"
+        ) + function(
             "engine/hexen2/cl_main.c", "void CL_EstablishConnection (const char *host)"
+        ) + function(
+            "engine/hexen2/cl_main.c", "int CL_ReadFromServer (void)"
         ) + JOIN_TESTS,
     }
     with tempfile.TemporaryDirectory(prefix="multiplayer-join-") as tmp:


### PR DESCRIPTION
Follow-up to #51 / #50.

## Problem
The production server at `168.138.68.8` returns a syntactically valid Hexen II `CCREP_ACCEPT` on the initial plain-address probe, but sends no H2 signon data. The client therefore committed to H2 too early and remained behind the loading plaque until `load timeout.`

## Fix
- treat an H2 control acceptance as provisional for plain joins
- confirm H2 only after the first real server message
- after five silent seconds (or an early qsocket drop), disconnect the provisional socket and continue bounded HW negotiation
- preserve `h2://` and `hw://` as strict overrides and preserve rejection behavior
- add unit coverage and a live silent-accept UDP fixture to `hw-smoke.sh`

## Verification
- `nix build .#default`: pass
- `nix develop --command python3 tools/test_multiplayer_join.py`: pass
- enhanced `scripts/hw-smoke.sh`: pass, including false H2 acceptance → HW signon, two clients, map change, Siege, and missing-content cases
- genuine local H2 plain join: signon stages 1–4 and first world draw, with no HW fallback
- production `168.138.68.8`: false H2 acceptance → bounded fallback → HW protocol 25 and gamedir `siege`; the currently selected custom server map then correctly reports the separately missing client asset `maps/siege1vlit10.bsp` instead of `load timeout.`
