### PR TITLE
fix(render): preserve multiplayer entity transparency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           name: hexenwail
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+      - name: Test multiplayer transparency state
+        run: nix develop -c python3 tools/test_multiplayer_transparency.py
+
       - name: Build Linux
         run: nix build .#nixos --print-build-logs
 

--- a/engine/hexen2/cl_hw.c
+++ b/engine/hexen2/cl_hw.c
@@ -602,8 +602,12 @@ static void HWCL_ParseEntityDelta (const hwcl_entity_state_t *from,
 	if (bits & (1 << 1)) to->angles[2] = MSG_ReadAngle ();
 	if (bits & (1 << 2)) to->scale = MSG_ReadByte ();
 	if (bits & (1 << 19)) to->abslight = MSG_ReadByte ();
-	if (bits & (1 << 17)) MSG_ReadShort (); /* sound index, routed later */
+	/* SV_WriteDelta writes the protocol-100 alpha extension before U_SOUND.
+	 * Keep this order even though U_SOUND has the lower bit number: consuming
+	 * sound first turns its high byte into alpha whenever both fields occur in
+	 * one delta, and leaves the packet stream one byte out of alignment. */
 	if (bits & (1 << 20)) to->alpha = MSG_ReadByte (); /* protocol 100 */
+	if (bits & (1 << 17)) MSG_ReadShort (); /* sound index, routed later */
 	to->active = true;
 }
 

--- a/engine/hexen2/cl_main.c
+++ b/engine/hexen2/cl_main.c
@@ -1316,6 +1316,17 @@ static void CL_RelinkEntities (void)
 		if (ent->effects & EF_NODRAW)
 			continue;
 
+#ifndef GLQUAKE
+		/* The 8bpp renderer has one palette translucency table rather than
+		 * arbitrary blend factors.  Preserve the protocol's important states:
+		 * ENTALPHA_ZERO is invisible, while every partial alpha uses the same
+		 * established path as DRF_TRANSLUCENT instead of rendering opaque. */
+		if (ent->alpha == ENTALPHA_ZERO)
+			continue;
+		if (ent->alpha != ENTALPHA_DEFAULT && !ENTALPHA_OPAQUE(ent->alpha))
+			ent->drawflags |= DRF_TRANSLUCENT;
+#endif
+
 		if (cl_numvisedicts < MAX_VISEDICTS)
 		{
 			cl_visedicts[cl_numvisedicts] = ent;

--- a/engine/hexen2/gl_rsurf.c
+++ b/engine/hexen2/gl_rsurf.c
@@ -990,6 +990,14 @@ static float R_BrushEntityAlpha (const entity_t *e, float fallback)
 		ENTALPHA_DECODE(e->alpha) : fallback;
 }
 
+static float R_BrushFenceThreshold (const entity_t *e)
+{
+	/* sworld_frag compares after tex.a has been multiplied by entity alpha.
+	 * Scale the cutoff by the same factor so it continues testing tex.a at
+	 * 0.666 instead of discarding an otherwise solid, translucent fence. */
+	return 0.666f * R_BrushEntityAlpha(e, 1.0f);
+}
+
 void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 {
 	texture_t	*t;
@@ -1198,9 +1206,11 @@ void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 			R_SetBlend (false);
 			R_SetDepthMask (true);
 		}
-		GL_SetAlphaThreshold(0.666f);
+		GL_SetAlphaThreshold(R_BrushFenceThreshold(e));
+		/* Alpha-to-coverage plus alpha blending attenuates explicit entity
+		 * alpha twice.  Keep A2C for the legacy opaque cutout only. */
 		if (r_alphatocoverage.integer)
-			R_SetAlphaToCoverage (true);
+			R_SetAlphaToCoverage (e->alpha == ENTALPHA_DEFAULT);
 	}
 
 	/* MLS_ABSLIGHT skip restored from pre-90265f406. Brush entities with

--- a/engine/hexen2/gl_rsurf.c
+++ b/engine/hexen2/gl_rsurf.c
@@ -978,12 +978,25 @@ R_RenderBrushPoly
 static float R_LiquidAlpha (const texture_t *t); /* forward decl */
 void R_LightmapRebuildIfDirty (msurface_t *surf);	/* defined below */
 
+static qboolean R_BrushEntityTranslucent (const entity_t *e)
+{
+	return (e->drawflags & DRF_TRANSLUCENT) ||
+		(e->alpha != ENTALPHA_DEFAULT && !ENTALPHA_OPAQUE(e->alpha));
+}
+
+static float R_BrushEntityAlpha (const entity_t *e, float fallback)
+{
+	return (e->alpha != ENTALPHA_DEFAULT) ?
+		ENTALPHA_DECODE(e->alpha) : fallback;
+}
+
 void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 {
 	texture_t	*t;
 	byte		*base;
 	int		maps;
 	float		intensity, alpha_val;
+	qboolean	entity_translucent;
 
 	c_brush_polys++;
 
@@ -991,8 +1004,9 @@ void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 
 	intensity = 1.0f;
 	alpha_val = 1.0f;
+	entity_translucent = R_BrushEntityTranslucent(e);
 
-	if (e->drawflags & DRF_TRANSLUCENT)
+	if (entity_translucent)
 	{
 		R_SetBlend (true);
 		/* Translucent surfaces must not write depth — otherwise the
@@ -1003,7 +1017,7 @@ void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 		if (!OIT_InPass())
 			R_SetBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		R_SetDepthMask (false);
-		alpha_val = r_wateralpha.value;
+		alpha_val = R_BrushEntityAlpha(e, r_wateralpha.value);
 	}
 	{
 		int mls = e->drawflags & MLS_MASKIN;
@@ -1030,11 +1044,11 @@ void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 	if (fa->flags & SURF_DRAWSKY)
 	{	// warp texture, no lightmaps
 		EmitBothSkyLayers (fa);
-		/* Restore the DRF_TRANSLUCENT prelude state — the cleanup at
+		/* Restore the translucent prelude state — the cleanup at
 		 * the bottom of this function is bypassed by this early return
 		 * and a leaked DepthMask=0 / BLEND-on would corrupt the next
 		 * draw call.  uhexen2-j001.  Gated for OIT pass. */
-		if ((e->drawflags & DRF_TRANSLUCENT) && !OIT_InPass())
+		if (entity_translucent && !OIT_InPass())
 		{
 			R_SetDepthMask (true);
 			R_SetBlend (false);
@@ -1059,11 +1073,13 @@ void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 
 	if (fa->flags & SURF_DRAWTURB)
 	{	// warp texture — apply per-liquid alpha + light tinting
-		float turb_alpha = R_LiquidAlpha(fa->texinfo->texture);
+		float turb_alpha = R_BrushEntityAlpha(e,
+			R_LiquidAlpha(fa->texinfo->texture));
 		qboolean turb_blend = (turb_alpha < 1.0f);
-		/* R_LiquidAlpha is authoritative for turb surfaces.  The
-		 * DRF_TRANSLUCENT block above set alpha_val = r_wateralpha and
-		 * enabled BLEND assuming a regular surface; for a turb surface
+		/* R_LiquidAlpha is authoritative for turb surfaces unless the entity
+		 * carries an explicit protocol alpha.  The translucent prelude otherwise
+		 * uses r_wateralpha and enables BLEND assuming a regular surface; for a
+		 * turb surface
 		 * (e.g. func_illusionary over a lava pit) we override with the
 		 * per-liquid alpha so default lava stays opaque even though
 		 * the brush ent is flagged translucent.  uhexen2-gbmv,
@@ -1173,11 +1189,11 @@ void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 
 	if (fa->flags & SURF_DRAWFENCE)
 	{
-		/* Alpha-tested cutout — surviving pixels are fully opaque, so
-		 * write depth normally even when the entity is DRF_TRANSLUCENT
-		 * (which set DepthMask=0 above).  uhexen2-t4kt.  Gated for OIT
-		 * pass. */
-		if (!OIT_InPass())
+		/* Alpha-tested cutout texels are opaque under the legacy drawflag,
+		 * but an explicit entity alpha must still modulate the surviving
+		 * pixels.  Keep blending/no-depth-write in that case.  uhexen2-t4kt.
+		 * Gated for OIT pass. */
+		if (!OIT_InPass() && e->alpha == ENTALPHA_DEFAULT)
 		{
 			R_SetBlend (false);
 			R_SetDepthMask (true);
@@ -1200,7 +1216,7 @@ void R_RenderBrushPoly (entity_t *e, msurface_t *fa, qboolean override)
 	 * surface actually renders — going through the MTex lightmap path
 	 * would multiply intensity by the baked lightmap and the effect
 	 * would be lost.  uhexen2-j7rp. */
-	if ((e->drawflags & DRF_TRANSLUCENT) ||
+	if (entity_translucent ||
 	    (e->drawflags & MLS_MASKIN) != MLS_NONE)
 	{
 		if (fa->flags & SURF_UNDERWATER)
@@ -1251,7 +1267,7 @@ dynamic:
 		R_BuildLightMap (fa, base, BLOCK_WIDTH*lightmap_bytes);
 	}
 
-	if (e->drawflags & DRF_TRANSLUCENT)
+	if (entity_translucent)
 	{
 		/* gated for OIT pass */
 		if (!OIT_InPass())
@@ -1276,9 +1292,9 @@ void R_RenderBrushPolyMTex (entity_t *e, msurface_t *fa, qboolean override)
 	int		maps;
 	float		intensity, alpha_val;
 
-	/* DRF_TRANSLUCENT entities are routed through R_RenderBrushPoly
-	 * (the non-MTex sibling) by DrawTextureChains' branch on
-	 * (DRF_TRANSLUCENT || ABSLIGHT); this MTex path is the else.  Dead
+	/* Translucent entities are routed through R_RenderBrushPoly (the non-MTex
+	 * sibling) by their caller; DrawTextureChains also branches on
+	 * (DRF_TRANSLUCENT || ABSLIGHT).  This MTex path is the opaque else.  Dead
 	 * DRF_TRANSLUCENT prelude + cleanup blocks (which had the same
 	 * depth-state leak the j001 fix repaired in R_RenderBrushPoly) were
 	 * removed in uhexen2-a5es. */

--- a/engine/hexen2/r_main.c
+++ b/engine/hexen2/r_main.c
@@ -1228,6 +1228,11 @@ static void R_EdgeDrawing (qboolean Translucent)
 			db_time1 = rw_time2;
 		}
 
+		/* Despite its historical name, this emits brush-model edges/surfaces; it
+		 * does not shade them immediately.  R_RenderBmodelFace propagates an
+		 * entity's DRF_TRANSLUCENT to SURF_TRANSLUCENT.  R_ScanEdges(false)
+		 * below skips those surfaces, then R_EdgeDrawing(true) reuses this saved
+		 * edge list and draws only them. */
 		R_DrawBEntitiesOnList ();
 
 		SaveSurfacesCount = surface_p - surfaces;

--- a/tools/test_multiplayer_transparency.py
+++ b/tools/test_multiplayer_transparency.py
@@ -111,6 +111,25 @@ def main():
     assert "GL_SetAlphaThreshold(R_BrushFenceThreshold(e));" in brush
     assert "R_SetAlphaToCoverage (e->alpha == ENTALPHA_DEFAULT);" in brush
 
+    # Pin the complete WEBSOFT brush route.  CL_RelinkEntities maps partial
+    # protocol alpha to DRF before publishing the entity; brush face emission
+    # propagates DRF to SURF_TRANSLUCENT; the first edge scan skips that flag
+    # and the saved second scan draws only that flag.
+    relink = function("engine/hexen2/cl_main.c", "static void CL_RelinkEntities")
+    adapt = relink.index("ent->drawflags |= DRF_TRANSLUCENT;")
+    publish = relink.index("cl_visedicts[cl_numvisedicts] = ent;")
+    assert adapt < publish
+    rdraw = (ROOT / "engine/h2shared/r_draw.c").read_text()
+    propagate = "surface_p->flags = psurf->flags | SURF_TRANSLUCENT;"
+    assert propagate in rdraw
+    edge_pass = function("engine/hexen2/r_main.c", "static void R_EdgeDrawing")
+    assert edge_pass.index("R_DrawBEntitiesOnList ();") < edge_pass.rindex(
+        "R_ScanEdges (Translucent);"
+    )
+    draw_surfaces = function("engine/h2shared/d_edge.c", "void D_DrawSurfaces")
+    assert "if (s->flags & SURF_TRANSLUCENT)\n\t\t\t\t\tcontinue;" in draw_surfaces
+    assert "if (!s->spans || !(s->flags & SURF_TRANSLUCENT))\n\t\t\t\t\tcontinue;" in draw_surfaces
+
     source = PRELUDE + function(
         "engine/hexen2/cl_hw.c", "static void HWCL_ParseEntityDelta"
     ) + function(

--- a/tools/test_multiplayer_transparency.py
+++ b/tools/test_multiplayer_transparency.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Data-free regression test for HexenWorld entity-alpha wire ordering.
+
+Extracts the production client delta parser, stubs its message reader, and feeds
+it a server-format update containing U_ALPHA and U_SOUND together.  This catches
+field-order drift without proprietary game data or a live server.
+"""
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def function(path, signature):
+    text = (ROOT / path).read_text()
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 1
+    end = brace + 1
+    while depth:
+        depth += (text[end] == "{") - (text[end] == "}")
+        end += 1
+    return text[start:end]
+
+
+PRELUDE = r'''
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+typedef int qboolean;
+#define true 1
+#define false 0
+#define DRF_TRANSLUCENT 128
+#define ENTALPHA_DEFAULT 0
+#define ENTALPHA_OPAQUE(a) ((uint8_t)((a)-1) >= 254)
+#define ENTALPHA_DECODE(a) (((a)==ENTALPHA_DEFAULT)?1.0f:((float)(a)-1)/254.0f)
+typedef struct { int drawflags; uint8_t alpha; } entity_t;
+typedef struct {
+    int active, modelindex, frame, colormap, skinnum, drawflags, effects;
+    float origin[3], angles[3];
+    int scale, abslight, alpha;
+} hwcl_entity_state_t;
+static const uint8_t *wire;
+static size_t wire_len, wire_pos;
+static int MSG_ReadByte(void) {
+    assert(wire_pos < wire_len);
+    return wire[wire_pos++];
+}
+static int MSG_ReadShort(void) {
+    int lo = MSG_ReadByte(), hi = MSG_ReadByte();
+    return (int16_t)(lo | (hi << 8));
+}
+static int MSG_ReadLong(void) {
+    int a = MSG_ReadShort(), b = MSG_ReadShort();
+    return a | (b << 16);
+}
+static float MSG_ReadCoord(void) { return (float)MSG_ReadShort() / 8.0f; }
+static float MSG_ReadAngle(void) { return (float)MSG_ReadByte() * (360.0f / 256.0f); }
+'''
+
+TEST = r'''
+int main(void) {
+    hwcl_entity_state_t from, to;
+    /* SV_WriteDelta order after the entity short: extension bytes, alpha,
+     * then the little-endian weapon sound. */
+    const uint8_t update[] = {0x80, 0x12, 0x80, 0x34, 0x12};
+    const int initial_bits = (1 << 15) | (1 << 7) | 7;
+
+    memset(&from, 0, sizeof(from));
+    from.alpha = 255;
+    wire = update; wire_len = sizeof(update); wire_pos = 0;
+    HWCL_ParseEntityDelta(&from, &to, initial_bits);
+    assert(to.alpha == 0x80);
+    assert(wire_pos == wire_len);
+
+    entity_t brush = {0, ENTALPHA_DEFAULT};
+    assert(!R_BrushEntityTranslucent(&brush));
+    brush.drawflags = DRF_TRANSLUCENT;
+    assert(R_BrushEntityTranslucent(&brush));
+    assert(R_BrushEntityAlpha(&brush, 0.4f) == 0.4f);
+    brush.drawflags = 0; brush.alpha = 128;
+    assert(R_BrushEntityTranslucent(&brush));
+    assert(R_BrushEntityAlpha(&brush, 0.4f) > 0.49f);
+    assert(R_BrushEntityAlpha(&brush, 0.4f) < 0.51f);
+    brush.alpha = 255;
+    assert(!R_BrushEntityTranslucent(&brush));
+    puts("PASS: HW wire order and explicit brush alpha routing");
+    return 0;
+}
+'''
+
+
+def main():
+    source = PRELUDE + function(
+        "engine/hexen2/cl_hw.c", "static void HWCL_ParseEntityDelta"
+    ) + function(
+        "engine/hexen2/gl_rsurf.c", "static qboolean R_BrushEntityTranslucent"
+    ) + function(
+        "engine/hexen2/gl_rsurf.c", "static float R_BrushEntityAlpha"
+    ) + TEST
+    with tempfile.TemporaryDirectory(prefix="multiplayer-transparency-") as tmp:
+        cfile = Path(tmp) / "wire.c"
+        binary = Path(tmp) / "wire"
+        cfile.write_text(source)
+        subprocess.run([
+            os.environ.get("CC", "cc"), "-std=c99", "-Wall", "-Wextra",
+            "-Werror", str(cfile), "-o", str(binary)
+        ], check=True)
+        subprocess.run([str(binary)], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_multiplayer_transparency.py
+++ b/tools/test_multiplayer_transparency.py
@@ -85,6 +85,15 @@ int main(void) {
     assert(R_BrushEntityTranslucent(&brush));
     assert(R_BrushEntityAlpha(&brush, 0.4f) > 0.49f);
     assert(R_BrushEntityAlpha(&brush, 0.4f) < 0.51f);
+    /* sworld_frag thresholds tex.a * entity_alpha.  A solid texel must
+     * survive and a below-cutoff texel must still be discarded. */
+    float entity_alpha = R_BrushEntityAlpha(&brush, 1.0f);
+    float fence_threshold = R_BrushFenceThreshold(&brush);
+    assert(entity_alpha >= fence_threshold);
+    assert(0.5f * entity_alpha < fence_threshold);
+    brush.alpha = ENTALPHA_DEFAULT;
+    assert(R_BrushFenceThreshold(&brush) > 0.665f);
+    assert(R_BrushFenceThreshold(&brush) < 0.667f);
     brush.alpha = 255;
     assert(!R_BrushEntityTranslucent(&brush));
     puts("PASS: HW wire order and explicit brush alpha routing");
@@ -100,6 +109,8 @@ def main():
         "engine/hexen2/gl_rsurf.c", "static qboolean R_BrushEntityTranslucent"
     ) + function(
         "engine/hexen2/gl_rsurf.c", "static float R_BrushEntityAlpha"
+    ) + function(
+        "engine/hexen2/gl_rsurf.c", "static float R_BrushFenceThreshold"
     ) + TEST
     with tempfile.TemporaryDirectory(prefix="multiplayer-transparency-") as tmp:
         cfile = Path(tmp) / "wire.c"

--- a/tools/test_multiplayer_transparency.py
+++ b/tools/test_multiplayer_transparency.py
@@ -103,6 +103,14 @@ int main(void) {
 
 
 def main():
+    shader = (ROOT / "engine/h2shared/gl_shader.c").read_text()
+    multiply = shader.index('"    vec4 color = tex * lm * v_color;\\n"')
+    discard = shader.index('"    if (color.a < u_alpha_threshold) discard;\\n"', multiply)
+    assert multiply < discard
+    brush = (ROOT / "engine/hexen2/gl_rsurf.c").read_text()
+    assert "GL_SetAlphaThreshold(R_BrushFenceThreshold(e));" in brush
+    assert "R_SetAlphaToCoverage (e->alpha == ENTALPHA_DEFAULT);" in brush
+
     source = PRELUDE + function(
         "engine/hexen2/cl_hw.c", "static void HWCL_ParseEntityDelta"
     ) + function(


### PR DESCRIPTION
## Summary
- consume HexenWorld protocol-100 `U_ALPHA` before `U_SOUND`, matching the server wire order
- apply explicit entity alpha to GL/GLES brush models, including turb and fence surfaces
- preserve partial/invisible alpha intent in the fixed-palette WEBSOFT renderer
- add a data-free production-function regression test and run it in CI

## Structural finding
Hexen II single-player and cooperative multiplayer share the same server delta, client parser, and renderer. The proven multiplayer-only split is HexenWorld protocol adaptation. The GL/GLES brush omission was common after alpha reached `entity_t`. Full path audit is recorded on #57.

## How it was tested
- `nix develop -c python3 tools/test_multiplayer_transparency.py`
- `python3 -m py_compile tools/test_multiplayer_transparency.py`
- `git diff --check`
- `nix build .#default .#h2ded .#hwsv --print-build-logs`
- `nix-shell shell-wasm.nix --run "./scripts/wasm-build.sh webgl2 /tmp/hexenwail-wasm-webgl2"`
- `nix-shell shell-wasm.nix --run "./scripts/wasm-build.sh software /tmp/hexenwail-wasm-software"`

The direct `nix build .#wasm` attempt reached Emscripten and failed only because its sandbox could not resolve GitHub while fetching the SDL3 port; the repository-documented `shell-wasm.nix` path succeeded for both renderers. Existing compiler warnings remain unchanged.

Closes #57.